### PR TITLE
[#51] fix: ErrorResponse 응답 형식 변경

### DIFF
--- a/src/main/java/com/kiero/global/response/dto/ErrorResponse.java
+++ b/src/main/java/com/kiero/global/response/dto/ErrorResponse.java
@@ -1,25 +1,30 @@
 package com.kiero.global.response.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.springframework.http.HttpStatus;
 
 import com.kiero.global.response.base.BaseCode;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record ErrorResponse(
 	int status,
-	String message
+	String message,
+    String detail
 ) {
 
 	public static ErrorResponse of(BaseCode baseCode) {
-		return new ErrorResponse(baseCode.getHttpStatus().value(), baseCode.getMessage());
+		return new ErrorResponse(baseCode.getHttpStatus().value(), baseCode.getMessage(), null);
 	}
 
 	public static ErrorResponse of(HttpStatus httpStatus, String message) { //메시지 추가 커스텀
-		return new ErrorResponse(httpStatus.value(), message);
+		return new ErrorResponse(httpStatus.value(), message, null);
 	}
 
 	public static ErrorResponse of(BaseCode baseCode, Object detail) { //디테일 추가 커스텀
-		return new ErrorResponse(baseCode.getHttpStatus().value(),
-			baseCode.getMessage() + (detail != null ? ": " + detail : "")
+		return new ErrorResponse(
+                baseCode.getHttpStatus().value(),
+                baseCode.getMessage(),
+                detail != null ? detail.toString() : null
 		);
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #51 

## Work Description ✏️

Error응답 시, 기존에 `message`필드에 detail 메세지까지 묶어서 보내던 방식에서, `detail`필드를 따로 분리해서 응답해주는 방식으로 수정했습니다.

## Trouble Shooting ⚽️


## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 오류 응답에 상세 정보 필드가 추가되었습니다. 기본 오류 메시지와 함께 추가적인 상세 정보를 포함하여 더욱 구체적인 오류 정보를 제공할 수 있습니다. 불필요한 null 값은 응답에서 자동으로 제외되어 더욱 효율적인 응답 구조를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->