### PR TITLE
[refactor] #61 - 미션 조회 api 응답에 요일 필드 추가

### DIFF
--- a/src/main/java/com/kiero/mission/presentation/dto/MissionsByDateResponse.java
+++ b/src/main/java/com/kiero/mission/presentation/dto/MissionsByDateResponse.java
@@ -1,10 +1,8 @@
 package com.kiero.mission.presentation.dto;
 
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.time.format.TextStyle;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public record MissionsByDateResponse(
@@ -12,6 +10,7 @@ public record MissionsByDateResponse(
 ) {
     public record DateGroupedMissions(
         String dueAt,
+        String dayOfWeek,
         List<MissionItemResponse> missions
     ) {
     }
@@ -29,12 +28,18 @@ public record MissionsByDateResponse(
         List<DateGroupedMissions> result = grouped.entrySet().stream()
             .sorted(Map.Entry.comparingByKey()) // 날짜순
             .map(entry -> {
+                LocalDate date = entry.getKey();
+
                 List<MissionItemResponse> sortedMissions = entry.getValue().stream()
                     .sorted(Comparator.comparing(MissionItemResponse::isCompleted)) // 미완료순
                     .toList();
 
+                String dayOfWeek = date.getDayOfWeek()
+                        .getDisplayName(TextStyle.FULL, Locale.KOREAN);
+
                 return new DateGroupedMissions(
-                    entry.getKey().toString(),
+                    date.toString(),
+                    dayOfWeek,
                     sortedMissions
                 );
             })


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #61 

## Work Description ✏️

기획 변경 사항에 따라서 미션 조회 API 응답 데이터에 요일 필드를 추가했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

### 미션 조회 API
<img width="1483" height="865" alt="미션리스트" src="https://github.com/user-attachments/assets/9a6cfc78-01e7-46bb-999c-fbf2247a2270" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 날짜별로 그룹화된 미션 목록에서 각 날짜에 해당하는 요일 정보(월요일, 화요일 등)가 한국어로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->