### PR TITLE
[feat] #64 - 일정 추가 뷰 디폴트 색상 조회 api 구현

### DIFF
--- a/src/main/java/com/kiero/schedule/domain/enums/ScheduleColor.java
+++ b/src/main/java/com/kiero/schedule/domain/enums/ScheduleColor.java
@@ -14,4 +14,10 @@ public enum ScheduleColor {
 	;
 
 	private final String colorCode;
+
+	public ScheduleColor next() {
+		ScheduleColor[] values = ScheduleColor.values();
+		int nextIndex = (this.ordinal() + 1) % values.length;
+		return values[nextIndex];
+	}
 }

--- a/src/main/java/com/kiero/schedule/exception/ScheduleSuccessCode.java
+++ b/src/main/java/com/kiero/schedule/exception/ScheduleSuccessCode.java
@@ -18,6 +18,7 @@ public enum ScheduleSuccessCode implements BaseCode {
 	NOW_SCHEDULE_SKIP_SUCCESS(HttpStatus.OK, "현재 일정 넘어가기 처리가 완료되었습니다."),
 	NOW_SCHEDULE_COMPLETE_SUCCESS(HttpStatus.OK, "현재 일정 완료 처리가 성공하였습니다."),
 	FIRE_LIT_SUCCESS(HttpStatus.OK, "마음의 불 피우기 요청이 성공하였습니다."),
+	DEFAULT_CONTENT_GET_SUCCESS(HttpStatus.OK, "일정 추가를 위한 기본 정보 조회가 성공하였습니다."),
 
 	/*
 	201 CREATED

--- a/src/main/java/com/kiero/schedule/presentation/ScheduleController.java
+++ b/src/main/java/com/kiero/schedule/presentation/ScheduleController.java
@@ -17,6 +17,7 @@ import com.kiero.global.auth.annotation.CurrentMember;
 import com.kiero.global.auth.dto.CurrentAuth;
 import com.kiero.global.response.dto.SuccessResponse;
 import com.kiero.schedule.exception.ScheduleSuccessCode;
+import com.kiero.schedule.presentation.dto.DefaultScheduleContentResponse;
 import com.kiero.schedule.presentation.dto.NowScheduleCompleteRequest;
 import com.kiero.schedule.presentation.dto.FireLitResponse;
 import com.kiero.schedule.presentation.dto.ScheduleAddRequest;
@@ -34,7 +35,7 @@ public class ScheduleController {
 
 	private final ScheduleService scheduleService;
 
-    @PreAuthorize("hasAnyRole('PARENT', 'ADMIN')")
+	@PreAuthorize("hasAnyRole('PARENT', 'ADMIN')")
 	@PostMapping("/{childId}")
 	public ResponseEntity<SuccessResponse<Void>> addSchedule(
 		@Valid @RequestBody ScheduleAddRequest request,
@@ -46,7 +47,7 @@ public class ScheduleController {
 			.body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_CREATED));
 	}
 
-    @PreAuthorize("hasAnyRole('PARENT', 'ADMIN')")
+	@PreAuthorize("hasAnyRole('PARENT', 'ADMIN')")
 	@GetMapping("/{childId}")
 	public ResponseEntity<SuccessResponse<ScheduleTabResponse>> getSchedules(
 		@RequestParam LocalDate startDate,
@@ -60,7 +61,7 @@ public class ScheduleController {
 			.body(SuccessResponse.of(ScheduleSuccessCode.SCHEDULE_TAB_GET_SUCCESS, response));
 	}
 
-    @PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
+	@PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
 	@PatchMapping("/today")
 	public ResponseEntity<SuccessResponse<TodayScheduleResponse>> updateAndGetTodaySchedule(
 		@CurrentMember CurrentAuth currentAuth
@@ -70,7 +71,7 @@ public class ScheduleController {
 			.body(SuccessResponse.of(ScheduleSuccessCode.TODAY_SCHEDULE_GET_SUCCESS, response));
 	}
 
-    @PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
+	@PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
 	@PatchMapping("/skip/{scheduleDetailId}")
 	public ResponseEntity<SuccessResponse<Void>> skipNowSchedule(
 		@PathVariable("scheduleDetailId") Long scheduleDetailId,
@@ -81,7 +82,7 @@ public class ScheduleController {
 			.body(SuccessResponse.of(ScheduleSuccessCode.NOW_SCHEDULE_SKIP_SUCCESS));
 	}
 
-    @PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
+	@PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
 	@PatchMapping("/{scheduleDetailId}")
 	public ResponseEntity<SuccessResponse<Void>> completeNowSchedule(
 		@Valid @RequestBody NowScheduleCompleteRequest request,
@@ -93,7 +94,7 @@ public class ScheduleController {
 			.body(SuccessResponse.of(ScheduleSuccessCode.NOW_SCHEDULE_COMPLETE_SUCCESS));
 	}
 
-    @PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
+	@PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
 	@PatchMapping("/fire-lit")
 	public ResponseEntity<SuccessResponse<FireLitResponse>> fireLit(
 		@CurrentMember CurrentAuth currentAuth
@@ -101,5 +102,16 @@ public class ScheduleController {
 		FireLitResponse response = scheduleService.fireLit(currentAuth.memberId());
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(ScheduleSuccessCode.FIRE_LIT_SUCCESS, response));
+	}
+
+	@PreAuthorize("hasAnyRole('PARENT', 'ADMIN')")
+	@GetMapping("/{childId}/default")
+	public ResponseEntity<SuccessResponse<DefaultScheduleContentResponse>> getDefaultScheduleContent(
+		@PathVariable("childId") Long childId,
+		@CurrentMember CurrentAuth currentAuth
+	) {
+		DefaultScheduleContentResponse response = scheduleService.getDefaultSchedule(currentAuth.memberId(), childId);
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(ScheduleSuccessCode.DEFAULT_CONTENT_GET_SUCCESS, response));
 	}
 }

--- a/src/main/java/com/kiero/schedule/presentation/dto/DefaultScheduleContentResponse.java
+++ b/src/main/java/com/kiero/schedule/presentation/dto/DefaultScheduleContentResponse.java
@@ -1,0 +1,9 @@
+package com.kiero.schedule.presentation.dto;
+
+import com.kiero.schedule.domain.enums.ScheduleColor;
+
+public record DefaultScheduleContentResponse(
+	ScheduleColor scheduleColor,
+	String colorCode
+) {
+}

--- a/src/main/java/com/kiero/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/kiero/schedule/repository/ScheduleRepository.java
@@ -3,6 +3,7 @@ package com.kiero.schedule.repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -35,4 +36,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 		@Param("todayDayOfWeek") DayOfWeek todayDayOfWeek,
 		@Param("today") LocalDate today
 	);
+
+	Optional<Schedule> findFirstByChildIdOrderByCreatedAtDesc(Long childId);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #64

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
childId로 해당하는 일정들 중 제일 마지막에 추가된 일정 색상을 추출하고, 다음 순서의 색상을 dto에 담아 보내는 api를 구현하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="817" height="542" alt="image" src="https://github.com/user-attachments/assets/2429a21e-e009-4428-a67b-88f46cd31593" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정 추가 시 기본 정보(색상) 조회 기능이 추가되었습니다.
  * 사용자가 새 일정을 생성할 때 자동으로 제안되는 색상 정보를 확인할 수 있습니다.
  * 색상은 순환 방식으로 자동 할당되어 일정 관리가 더욱 직관적이 됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->