### PR TITLE
[fix] #88 - docker-compsoe를 docker compose로 변경

### DIFF
--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -59,7 +59,8 @@ cd "$PROJECT_ROOT"
 
 log_info "프로젝트 디렉토리: $PROJECT_ROOT"
 
-docker-compose -f "$COMPOSE_FILE" up -d redis prometheus grafana
+log_info "redis, prometheus, grafa 컨테이너를 띄웁니다."
+docker compose -f "$COMPOSE_FILE" up -d redis prometheus grafana
 
 # EC2 Nginx 설정 파일 경로
 NGINX_CONF="/etc/nginx/sites-available/kiero"
@@ -110,7 +111,7 @@ else
     log_info "Blue 이미지 태그: $BLUE_TAG"
 fi
 
-docker-compose -f "$COMPOSE_FILE" pull app-$INACTIVE
+docker compose -f "$COMPOSE_FILE" pull app-$INACTIVE
 
 ###############################################################################
 # 3. 비활성 환경에 새 버전 배포
@@ -119,11 +120,11 @@ docker-compose -f "$COMPOSE_FILE" pull app-$INACTIVE
 log_info "$INACTIVE 환경에 새 버전 배포 중..."
 
 # 기존 비활성 컨테이너 정지 및 제거
-docker-compose -f "$COMPOSE_FILE" stop app-$INACTIVE || true
-docker-compose -f "$COMPOSE_FILE" rm -f app-$INACTIVE || true
+docker compose -f "$COMPOSE_FILE" stop app-$INACTIVE || true
+docker compose -f "$COMPOSE_FILE" rm -f app-$INACTIVE || true
 
 # 새 컨테이너 시작
-docker-compose -f "$COMPOSE_FILE" up -d app-$INACTIVE
+docker compose -f "$COMPOSE_FILE" up -d app-$INACTIVE
 
 log_info "$INACTIVE 컨테이너 시작 완료. Health check 대기 중..."
 
@@ -157,7 +158,7 @@ done
 if [ "$HEALTH_STATUS" != "healthy" ]; then
     log_error "$INACTIVE 환경이 정상적으로 시작되지 않았습니다. 배포를 중단합니다."
     log_error "로그 확인: docker logs ${CONTAINER_PREFIX}-${INACTIVE}"| tail -n 100
-    docker-compose -f "$COMPOSE_FILE" stop app-$INACTIVE
+    docker compose -f "$COMPOSE_FILE" stop app-$INACTIVE
     exit 1
 fi
 
@@ -200,7 +201,7 @@ else
     log_info "10초 후 이전 버전($ACTIVE)을 정지합니다. (Ctrl+C로 취소 가능)"
     sleep 10
 
-    docker-compose -f "$COMPOSE_FILE" stop app-$ACTIVE
+    docker compose -f "$COMPOSE_FILE" stop app-$ACTIVE
     log_success "이전 버전($ACTIVE) 정지 완료"
 fi
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #88

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
배포가 실패해서 찾아보니, docker-compose가 구버전이라 docker 이미지 메타데이터를 못읽으면 
제가 확인한 keyError: 'ContainerConfig'가 발생할 수 있다고 하더라고요. 

v2인 docker compose를 인스턴스 내에서 설치하고, 배포 스크립트의 docker-compose를 docker compose로 수정하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 스크립트의 Docker 명령 구문을 최신 버전으로 업데이트했습니다.
  * 배포 프로세스의 로깅을 개선했습니다.
  * 배포 인프라의 일관성을 강화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->