### PR TITLE
[feat] #108 - 추가하려는 일정의 시각이 기존 일정의 시각과 겹칠 때 예외를 던지도록 로직 추가

### DIFF
--- a/src/main/java/com/kiero/schedule/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/kiero/schedule/exception/ScheduleErrorCode.java
@@ -21,6 +21,7 @@ public enum ScheduleErrorCode implements BaseCode {
 	DAY_OF_WEEK_NOT_NULLABLE_WHEN_IS_RECURRING_IS_TRUE(HttpStatus.BAD_REQUEST, "반복 일정일 때, 반복요일이 입력되어야 합니다."),
 	DATE_NOT_NULLABLE_WHEN_IS_RECURRING_IS_FALSE(HttpStatus.BAD_REQUEST, "반복 일정이 아닐 때, 일정 일자가 입력되어야 합니다."),
 	INVALID_DATE_DURATION(HttpStatus.BAD_REQUEST, "시작 일자가 종료 일자의 이전 시점이어야 합니다."),
+	SCHEDULE_DUPLICATED(HttpStatus.BAD_REQUEST, "기존의 일정과 시간이 중복되는 일정은 추가할 수 없습니다."),
 
 	/*
 	403 FORBIDDEN

--- a/src/main/java/com/kiero/schedule/repository/ScheduleDetailRepository.java
+++ b/src/main/java/com/kiero/schedule/repository/ScheduleDetailRepository.java
@@ -50,4 +50,6 @@ public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, 
 		@Param("date") LocalDate date,
 		@Param("childId") Long childId
 	);
+
+	List<ScheduleDetail> findAllByScheduleChildIdAndDateGreaterThanEqual(Long childId, LocalDate date);
 }

--- a/src/main/java/com/kiero/schedule/repository/ScheduleRepeatDaysRepository.java
+++ b/src/main/java/com/kiero/schedule/repository/ScheduleRepeatDaysRepository.java
@@ -41,4 +41,27 @@ public interface ScheduleRepeatDaysRepository extends JpaRepository<ScheduleRepe
 		@Param("date") LocalDate date
 	);
 
+	@Query("""
+		select s
+		from ScheduleRepeatDays srd
+		join srd.schedule s
+		where srd.dayOfWeek in :dayOfWeeks
+			and s.child.id = :childId
+		""")
+	List<Schedule> findSchedulesByChildIdAndDayOfWeeks(
+		@Param("childId") Long childId,
+		@Param("dayOfWeeks") List<DayOfWeek> dayOfWeeks
+	);
+
+	@Query("""
+		select distinct s
+		from ScheduleRepeatDays srd
+		join srd.schedule s
+		where srd.dayOfWeek = :dayOfWeek
+		  and s.child.id = :childId
+		""")
+	List<Schedule> findSchedulesByChildIdAndDayOfWeek(
+		@Param("childId") Long childId,
+		@Param("dayOfWeek") DayOfWeek dayOfWeek
+	);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #105

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
클라이언트 요청으로 추가하려는 일정의 시각이 기존 등록되어 있는 일정의 시각과 겹칠 때 예외를 던지도록 로직을 추가하였습니다.
추가하려는 일정이 반복일정일 때, 단일일정일 때  모두 쿼리가 2개씩 추가 발생합니다. 


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->
<img width="893" height="575" alt="image" src="https://github.com/user-attachments/assets/82a5a434-2e81-41f0-a16c-4f26736a1855" />
<img width="875" height="551" alt="image" src="https://github.com/user-attachments/assets/740d0e09-e6a6-4af5-9e98-c022f0974724" />


## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선 사항

* **버그 수정**
  * 일정 생성 시 기존 일정과 시간 중복을 사전 감지해 차단하고, 중복인 경우 명확한 오류(400)를 반환합니다.
* **기능 개선**
  * 특정 날짜 또는 요일 기준으로 일정을 더 정확하게 조회할 수 있도록 검색 범위를 확장했습니다.
* **테스트**
  * 시간에 민감한 일정 동작을 안정적으로 검증하도록 테스트 시나리오와 시계 제어를 보강했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->