### PR TITLE
[refactor] #114 - 반복일정이 추가되면 추가된 그 주부터 반복일정이 노출되도록 수정

### DIFF
--- a/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
@@ -1001,6 +1001,8 @@ public class ScheduleServiceTest {
 			ScheduleRepeatDays rdMon = mock(ScheduleRepeatDays.class);
 			ScheduleRepeatDays rdWed = mock(ScheduleRepeatDays.class);
 
+			given(schedule.getCreatedAt()).willReturn(LocalDateTime.of(2025, 12, 29, 10, 0));
+
 			given(parentRepository.findById(parentId)).willReturn(Optional.of(parent));
 			given(childRepository.findById(childId)).willReturn(Optional.of(child));
 			given(parentChildRepository.existsByParentAndChild(parent, child)).willReturn(true);


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #114  

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
반복일정이 n번째 주에 추가됐을 때, n주 이전의 주차 일정 조회 시에도 반복일정이 노출되던 이슈를 수정하였습니다. 

요구 사항을 
이번주에 등록된 반복일정은 저번주 일정 조회 시 조회되지 않아야한다
=> 반복일정이 추가되면 추가된 그 주부터 반복일정이 노출된다.

로 정의하였습니다. 

일정 조회 시 각 조회된 반복일정의 createdAt을 기준으로, createdAt이 속한 주차의 월요일이 며칠인지 계산했습니다. 쿼리 파라미터로 얻은 startDate가 속한 주차의 월요일이 며칠인지 계산했습니다. createdAt이 속한 주차의 월요일이 startDate가 속한 주차의 월요일보다 이전이라면 ( 등록된 주 <= 조회하는 주 )면 노출되고, 그렇지 않으면 노출되지 않도록 처리했습니다. 
 
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### n주차에 등록된 일정을 n주차에 조회할 때
<img width="881" height="695" alt="image" src="https://github.com/user-attachments/assets/2e098dc0-463d-4c24-8c04-32bfafb353fb" />


### n주차에 등록된 일정을 n+1주차에 조회할 때
<img width="876" height="700" alt="image" src="https://github.com/user-attachments/assets/d9672fd0-a8f9-4bbf-9567-d1df4685d197" />

### n주차에 등록된 일정을 n-1주차에 조회할 때
<img width="871" height="470" alt="image" src="https://github.com/user-attachments/assets/41535628-0265-4e69-b055-fbdfbf02ac9a" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 반복 일정에 대한 향상된 필터링 및 주간 기반 표시 추가
  * 일정 정보에 색상 코드 및 이름 통합

* **Bug Fixes**
  * 입력 값 검증 및 날짜-기간 유효성 검사 강화

* **Tests**
  * 반복 일정 처리 테스트 케이스 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->