### PR TITLE
[fix] #130 - 하루에 일정이 하나밖에 없고, 일정을 완료했을 때 불피우기 버튼이 뜨지 않는 버그 수정

### DIFF
--- a/src/main/java/com/kiero/schedule/service/resolver/TodayScheduleStatusResolver.java
+++ b/src/main/java/com/kiero/schedule/service/resolver/TodayScheduleStatusResolver.java
@@ -32,7 +32,7 @@ public final class TodayScheduleStatusResolver {
 			int index = filteredAllScheduleDetails.indexOf(todoScheduleDetail);
 			int order = index + 1;
 
-			if (order == 1) {
+			if (order == 1 && todoScheduleDetail.getScheduleStatus().equals(ScheduleStatus.PENDING)) {
 				return TodayScheduleStatus.FIRST_SCHEDULE;
 			}
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #130

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
제곧내 ㅎㅎ 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 첫 번째 일정 식별 로직을 개선했습니다. 순서가 첫 번째일 때 동시에 대기 중 상태를 확인하여 일정 상태 관리의 정확성을 향상시켰습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->