### PR TITLE
[fix] #134 - 모든 일정을 스킵하거나 실패한 경우, 얻은 불조각 수가 0개일 때 FIRE_LIT을 반환하도록 수정

### DIFF
--- a/src/main/java/com/kiero/schedule/service/ScheduleService.java
+++ b/src/main/java/com/kiero/schedule/service/ScheduleService.java
@@ -127,6 +127,7 @@ public class ScheduleService {
 		boolean isSkippable = nextTodoScheduleDetail != null;
 
 		TodayScheduleStatus todayScheduleStatus = TodayScheduleStatusResolver.resolve(
+			earnedStones,
 			todoScheduleDetail,
 			filteredAllScheduleDetails,
 			earliestStoneUsedAt

--- a/src/main/java/com/kiero/schedule/service/resolver/TodayScheduleStatusResolver.java
+++ b/src/main/java/com/kiero/schedule/service/resolver/TodayScheduleStatusResolver.java
@@ -16,6 +16,7 @@ public final class TodayScheduleStatusResolver {
 	}
 
 	public static TodayScheduleStatus resolve(
+		int earnedStones,
 		ScheduleDetail todoScheduleDetail,
 		List<ScheduleDetail> filteredAllScheduleDetails,
 		LocalDateTime earliestStoneUsedAt
@@ -35,6 +36,7 @@ public final class TodayScheduleStatusResolver {
 			// 일정을 모두 완료하고, 불피우기는 진행하지 않았을 때
 			if (passedScheduleCount == totalSchedule && earliestStoneUsedAt == null) {
 				log.info("totalSchedule" + totalSchedule + "passedScheduleCount" + passedScheduleCount);
+				if (earnedStones == 0) { return TodayScheduleStatus.FIRE_LIT; }
 				return TodayScheduleStatus.FIRE_NOT_LIT;
 			}
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #134

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
제곧내

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 스케줄 완료 상태 판정 로직 개선: 획득한 스톤 수를 기반으로 더 정확한 일일 스케줄 상태를 표시합니다.

* **개선**
  * 스케줄 상태 결정 과정에서 획득한 스톤 정보를 추가로 반영하여 완료 조건의 정확성을 향상시켰습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->