### PR TITLE
[refactor] #138 - 모든 일정을 스킵하거나 실패했을 경우, NO_SCHEDULE status를 반환하도록 수정

### DIFF
--- a/src/main/java/com/kiero/schedule/service/resolver/TodayScheduleStatusResolver.java
+++ b/src/main/java/com/kiero/schedule/service/resolver/TodayScheduleStatusResolver.java
@@ -33,10 +33,12 @@ public final class TodayScheduleStatusResolver {
 				.filter(sd -> sd.getScheduleStatus() != ScheduleStatus.PENDING)
 				.count();
 
-			// 일정을 모두 완료하고, 불피우기는 진행하지 않았을 때
+			// 일정을 모두 거쳤고, 불피우기는 진행하지 않았을 때
 			if (passedScheduleCount == totalSchedule && earliestStoneUsedAt == null) {
 				log.info("totalSchedule" + totalSchedule + "passedScheduleCount" + passedScheduleCount);
-				if (earnedStones == 0) { return TodayScheduleStatus.FIRE_LIT; }
+				// 모든 일정을 스킵하거나 실패해서 얻은 불조각 수가 0개일 때
+				if (earnedStones == 0) { return TodayScheduleStatus.NO_SCHEDULE; }
+
 				return TodayScheduleStatus.FIRE_NOT_LIT;
 			}
 

--- a/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
@@ -1189,7 +1189,7 @@ public class ScheduleServiceTest {
 			assertThat(response.scheduleOrder()).isEqualTo(0);
 			assertThat(response.totalSchedule()).isEqualTo(0);
 			assertThat(response.earnedStones()).isEqualTo(0);
-			assertThat(response.scheduleStatus()).isEqualTo(TodayScheduleStatus.FIRE_LIT);
+			assertThat(response.scheduleStatus()).isEqualTo(TodayScheduleStatus.NO_SCHEDULE);
 			assertThat(response.isSkippable()).isFalse();
 			assertThat(response.isNowScheduleVerified()).isFalse();
 		}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #138

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 일정 상태 표시가 개선되었습니다. 오늘의 모든 일정을 처리했으나 추가 활동을 진행하지 않은 경우 시스템이 정확한 상태를 표시하도록 수정되었습니다. 사용자는 이제 앱에서 더욱 명확하고 정확한 상태 정보를 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->