### PR TITLE
[chore] #161 - rt, at를 모두 재발급하는 로직 삭제

### DIFF
--- a/src/main/java/com/kiero/global/auth/jwt/adapter/in/web/MemberTokenController.java
+++ b/src/main/java/com/kiero/global/auth/jwt/adapter/in/web/MemberTokenController.java
@@ -1,7 +1,5 @@
 package com.kiero.global.auth.jwt.adapter.in.web;
 
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -44,29 +42,6 @@ public class MemberTokenController {
 		AccessTokenGenerateResponse response = memberTokenUseCase.reissueAccessToken(refreshToken);
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(TokenSuccessCode.ACCESS_TOKEN_REISSUE_SUCCESS, response));
-	}
-
-	@PostMapping("/reissue/tokens")
-	public ResponseEntity<SuccessResponse<AccessTokenGenerateResponse>> reissueTokens(
-		@CookieValue("refreshToken") String refreshToken
-	) {
-
-		MemberTokenUseCase.ReissueTokensResult result = memberTokenUseCase.reissueTokens(refreshToken);
-
-		ResponseCookie cookie = ResponseCookie.from("refreshToken", result.newRefreshToken())
-			.httpOnly(true)
-			.secure(true)
-			.sameSite("None")
-			.path("/")
-			.maxAge(7 * 24 * 60 * 60)
-			.build();
-
-		return ResponseEntity.ok()
-			.header(HttpHeaders.SET_COOKIE, cookie.toString())
-			.body(SuccessResponse.of(
-				TokenSuccessCode.TOKENS_REISSUE_SUCCESS,
-				result.accessTokenResponse()
-			));
 	}
 
 	@PostMapping("/subscribe-token")

--- a/src/main/java/com/kiero/global/auth/jwt/adapter/out/AuthServiceAdapter.java
+++ b/src/main/java/com/kiero/global/auth/jwt/adapter/out/AuthServiceAdapter.java
@@ -20,11 +20,6 @@ public class AuthServiceAdapter implements AuthTokenPort {
 	}
 
 	@Override
-	public String reissueRefreshToken(String refreshToken) {
-		return authService.reissueRefreshToken(refreshToken);
-	}
-
-	@Override
 	public AccessTokenGenerateResponse generateSubscribeToken(String refreshToken) {
 		return authService.generateSubscribeToken(refreshToken);
 	}

--- a/src/main/java/com/kiero/global/auth/jwt/application/port/in/MemberTokenUseCase.java
+++ b/src/main/java/com/kiero/global/auth/jwt/application/port/in/MemberTokenUseCase.java
@@ -9,12 +9,5 @@ public interface MemberTokenUseCase {
 
 	AccessTokenGenerateResponse reissueAccessToken(String refreshToken);
 
-	ReissueTokensResult reissueTokens(String refreshToken);
-
 	AccessTokenGenerateResponse issueSubscribeToken(String refreshToken);
-
-	record ReissueTokensResult(
-		String newRefreshToken,
-		AccessTokenGenerateResponse accessTokenResponse
-	) {}
 }

--- a/src/main/java/com/kiero/global/auth/jwt/application/port/out/AuthTokenPort.java
+++ b/src/main/java/com/kiero/global/auth/jwt/application/port/out/AuthTokenPort.java
@@ -4,6 +4,5 @@ import com.kiero.global.auth.jwt.application.dto.AccessTokenGenerateResponse;
 
 public interface AuthTokenPort {
 	AccessTokenGenerateResponse generateAccessTokenFromRefreshToken(String refreshToken);
-	String reissueRefreshToken(String refreshToken);
 	AccessTokenGenerateResponse generateSubscribeToken(String refreshToken);
 }

--- a/src/main/java/com/kiero/global/auth/jwt/application/service/MemberTokenService.java
+++ b/src/main/java/com/kiero/global/auth/jwt/application/service/MemberTokenService.java
@@ -58,16 +58,6 @@ public class MemberTokenService implements MemberTokenUseCase {
 
 	@Override
 	@Transactional
-	public ReissueTokensResult reissueTokens(String refreshToken) {
-		String newRefreshToken = authTokenPort.reissueRefreshToken(refreshToken);
-		AccessTokenGenerateResponse accessTokenResponse =
-			authTokenPort.generateAccessTokenFromRefreshToken(newRefreshToken);
-
-		return new ReissueTokensResult(newRefreshToken, accessTokenResponse);
-	}
-
-	@Override
-	@Transactional
 	public AccessTokenGenerateResponse issueSubscribeToken(String refreshToken) {
 		return authTokenPort.generateSubscribeToken(refreshToken);
 	}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #161

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
아이가 재로그인 불가하기 때문에, at를 재발급하며 rt도 재발급해 사실상 무한 ttl을 가지도록 짜뒀던 로직을 일괄 삭제하였습니다. 
이제 아이의 세션 만료를 가정하고, 세션 만료 시 부모의 초대코드 재발급을 통한 재로그인을 수행합니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경 사항**
  * `/reissue/tokens` 엔드포인트가 제거되었습니다. 토큰 관리 시스템의 내부 구조가 개선되었으며, 기존 토큰 재발급 기능의 워크플로우가 업데이트되었습니다. 다른 토큰 관련 엔드포인트는 영향을 받지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->