### PR TITLE
[refactor] #170 - 불조각 종류를 정적으로 계산하도록 수정

### DIFF
--- a/src/main/java/com/kiero/schedule/adapter/in/scheduler/DailyScheduleJob.java
+++ b/src/main/java/com/kiero/schedule/adapter/in/scheduler/DailyScheduleJob.java
@@ -2,7 +2,6 @@ package com.kiero.schedule.adapter.in.scheduler;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.kiero.schedule.application.service.ScheduleCommandService;
 
@@ -14,7 +13,6 @@ public class DailyScheduleJob {
 
 	private final ScheduleCommandService scheduleCommandService;
 
-	@Transactional
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void runDailyJob() {
 		scheduleCommandService.createTodayScheduleDetail();

--- a/src/main/java/com/kiero/schedule/adapter/in/web/ScheduleController.java
+++ b/src/main/java/com/kiero/schedule/adapter/in/web/ScheduleController.java
@@ -68,7 +68,7 @@ public class ScheduleController {
 	public ResponseEntity<SuccessResponse<TodayScheduleResponse>> updateAndGetTodaySchedule(
 		@CurrentMember CurrentAuth currentAuth
 	) {
-		TodayScheduleResponse response = scheduleQueryUseCase.getTodaySchedule(currentAuth.memberId());
+		TodayScheduleResponse response = scheduleCommandUseCase.getTodaySchedule(currentAuth.memberId());
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(ScheduleSuccessCode.TODAY_SCHEDULE_GET_SUCCESS, response));
 	}

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
@@ -33,7 +33,8 @@ public class ScheduleDetailPersistenceAdapter implements ScheduleDetailPersisten
 	}
 
 	@Override
-	public List<ScheduleDetail> findAllByScheduleIdInAndDateBetween(List<Long> scheduleIds, LocalDate startDate, LocalDate endDate) {
+	public List<ScheduleDetail> findAllByScheduleIdInAndDateBetween(List<Long> scheduleIds, LocalDate startDate,
+		LocalDate endDate) {
 		return scheduleDetailRepository.findAllByScheduleIdInAndDateBetween(scheduleIds, startDate, endDate);
 	}
 
@@ -48,8 +49,8 @@ public class ScheduleDetailPersistenceAdapter implements ScheduleDetailPersisten
 	}
 
 	@Override
-	public void saveAll(List<ScheduleDetail> details) {
-		scheduleDetailRepository.saveAll(details);
+	public List<ScheduleDetail> saveAll(List<ScheduleDetail> details) {
+		return scheduleDetailRepository.saveAll(details);
 	}
 
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
@@ -28,6 +28,11 @@ public class ScheduleDetailPersistenceAdapter implements ScheduleDetailPersisten
 	}
 
 	@Override
+	public List<ScheduleDetail> findAllByDate(LocalDate date) {
+		return scheduleDetailRepository.findAllByDate(date);
+	}
+
+	@Override
 	public List<ScheduleDetail> findByDateInAndChildId(List<LocalDate> dates, Long childId) {
 		return scheduleDetailRepository.findByDateInAndChildId(dates, childId);
 	}

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
@@ -55,6 +55,18 @@ public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, 
 		select sd
 		from ScheduleDetail sd
 		join fetch sd.schedule s
+		join fetch s.child c
+		where sd.date = :date
+		"""
+	)
+	List<ScheduleDetail> findAllByDate(
+		@Param("date") LocalDate date
+	);
+
+	@Query("""
+		select sd
+		from ScheduleDetail sd
+		join fetch sd.schedule s
 		where sd.date in :dates
 		  and s.child.id = :childId
 		order by s.startTime asc

--- a/src/main/java/com/kiero/schedule/application/port/in/ScheduleCommandUseCase.java
+++ b/src/main/java/com/kiero/schedule/application/port/in/ScheduleCommandUseCase.java
@@ -3,10 +3,13 @@ package com.kiero.schedule.application.port.in;
 import com.kiero.schedule.application.dto.FireLitResponse;
 import com.kiero.schedule.application.dto.NowScheduleCompleteRequest;
 import com.kiero.schedule.application.dto.ScheduleAddRequest;
+import com.kiero.schedule.application.dto.TodayScheduleResponse;
 
 public interface ScheduleCommandUseCase {
 
 	void addSchedule(ScheduleAddRequest request, Long parentId, Long childId);
+
+	TodayScheduleResponse getTodaySchedule(Long childId);
 
 	void skipNowSchedule(Long childId, Long scheduleDetailId);
 

--- a/src/main/java/com/kiero/schedule/application/port/in/ScheduleQueryUseCase.java
+++ b/src/main/java/com/kiero/schedule/application/port/in/ScheduleQueryUseCase.java
@@ -4,11 +4,8 @@ import java.time.LocalDate;
 
 import com.kiero.schedule.application.dto.DefaultScheduleContentResponse;
 import com.kiero.schedule.application.dto.ScheduleTabResponse;
-import com.kiero.schedule.application.dto.TodayScheduleResponse;
 
 public interface ScheduleQueryUseCase {
-
-	TodayScheduleResponse getTodaySchedule(Long childId);
 
 	ScheduleTabResponse getSchedules(LocalDate startDate, LocalDate endDate, Long parentId, Long childId);
 

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
@@ -12,6 +12,8 @@ public interface ScheduleDetailPersistencePort {
 
 	List<ScheduleDetail> findByDateAndChildId(LocalDate date, Long childId);
 
+	List<ScheduleDetail> findAllByDate(LocalDate date);
+
 	List<ScheduleDetail> findByDateInAndChildId(List<LocalDate> dates, Long childId);
 
 	List<ScheduleDetail> findAllByScheduleIdInAndDateBetween(List<Long> scheduleIds, LocalDate startDate,

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
@@ -14,12 +14,13 @@ public interface ScheduleDetailPersistencePort {
 
 	List<ScheduleDetail> findByDateInAndChildId(List<LocalDate> dates, Long childId);
 
-	List<ScheduleDetail> findAllByScheduleIdInAndDateBetween(List<Long> scheduleIds, LocalDate startDate, LocalDate endDate);
+	List<ScheduleDetail> findAllByScheduleIdInAndDateBetween(List<Long> scheduleIds, LocalDate startDate,
+		LocalDate endDate);
 
 	boolean existsStoneUsedToday(List<Long> scheduleIds, LocalDate date);
 
 	List<ScheduleDetail> findAllByScheduleChildIdAndDateGreaterThanEqual(Long childId, LocalDate date);
 
-	void saveAll(List<ScheduleDetail> details);
+	List<ScheduleDetail> saveAll(List<ScheduleDetail> details);
 
 }

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -7,7 +7,9 @@ import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.springframework.stereotype.Service;
@@ -296,24 +298,36 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			.map(schedule -> ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, schedule))
 			.toList();
 
-		List<ScheduleDetail> savedScheduleDetails = detailPort.saveAll(scheduleDetails);
-		calculateStoneTypePerScheduleDetail(savedScheduleDetails);
+		detailPort.saveAll(scheduleDetails);
+
+		List<ScheduleDetail> allScheduleDetails = detailPort.findAllByDate(today);
+
+		calculateStoneTypePerScheduleDetail(allScheduleDetails);
 	}
 
 	private void calculateStoneTypePerScheduleDetail(List<ScheduleDetail> scheduleDetails) {
 
 		if (scheduleDetails.isEmpty()) return;
 
-		List<ScheduleDetail> orderedScheduleDetails = scheduleDetails.stream()
-			.sorted(Comparator.comparing(
-				detail -> detail.getSchedule().getStartTime()))
-			.toList();
+		Map<Long, List<ScheduleDetail>> byChild = scheduleDetails.stream()
+			.collect(Collectors.groupingBy(sd -> sd.getSchedule().getChild().getId()));
 
-		for (ScheduleDetail sd : orderedScheduleDetails) {
-			switch (scheduleDetails.indexOf(sd) % 3) {
-				case 0 -> sd.changeStoneType(StoneType.COURAGE);
-				case 1 -> sd.changeStoneType(StoneType.GRIT);
-				case 2 -> sd.changeStoneType(StoneType.WISDOM);
+
+		for (List<ScheduleDetail> childDetails : byChild.values()) {
+			childDetails.sort(
+				Comparator
+					.comparing((ScheduleDetail sd) -> sd.getSchedule().getStartTime())
+					.thenComparing(sd -> sd.getSchedule().getId())
+			);
+
+			for (int i = 0; i < childDetails.size(); i++) {
+				ScheduleDetail sd = childDetails.get(i);
+
+				switch (i % 3) {
+					case 0 -> sd.changeStoneType(StoneType.COURAGE);
+					case 1 -> sd.changeStoneType(StoneType.GRIT);
+					case 2 -> sd.changeStoneType(StoneType.WISDOM);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -130,7 +130,11 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 	public TodayScheduleResponse getTodaySchedule(Long childId) {
 		LocalDate today = LocalDate.now(clock);
 
-		List<ScheduleDetail> allScheduleDetails = detailPort.findByDateAndChildId(today, childId);
+		List<ScheduleDetail> allScheduleDetails = detailPort.findByDateAndChildId(today, childId).stream()
+			.sorted(Comparator
+					.comparing((ScheduleDetail sd) -> sd.getSchedule().getStartTime())
+					.thenComparing(sd -> sd.getSchedule().getId()))
+			.toList();
 
 		List<ScheduleDetail> pendingAndVerified = allScheduleDetails.stream()
 			.filter(sd -> sd.getScheduleStatus() == ScheduleStatus.PENDING || sd.getScheduleStatus() == ScheduleStatus.VERIFIED)

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -105,6 +105,75 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 	@Override
 	@Transactional
+	public TodayScheduleResponse getTodaySchedule(Long childId) {
+		LocalDate today = LocalDate.now(clock);
+
+		List<ScheduleDetail> allScheduleDetails = detailPort.findByDateAndChildId(today, childId);
+
+		List<ScheduleDetail> pendingAndVerified = allScheduleDetails.stream()
+			.filter(sd -> sd.getScheduleStatus() == ScheduleStatus.PENDING || sd.getScheduleStatus() == ScheduleStatus.VERIFIED)
+			.toList();
+
+		LocalDateTime earliestStoneUsedAt = findEarliestStoneUsedAt(allScheduleDetails);
+
+		List<ScheduleDetail> filteredPendingAndVerified = filterTodayCreatedSchedules(today, pendingAndVerified, earliestStoneUsedAt);
+		List<ScheduleDetail> filteredAllScheduleDetails = filterTodayCreatedSchedules(today, allScheduleDetails, earliestStoneUsedAt);
+
+		markPassedPendingSchedulesAsFailed(filteredPendingAndVerified);
+		markPassedVerifiedSchedulesAsCompleted(filteredPendingAndVerified);
+
+		List<ScheduleDetail> todo2 = findTodoScheduleAndNextTodoSchedule(filteredPendingAndVerified);
+		ScheduleDetail todo = todo2.size() > 0 ? todo2.get(0) : null;
+		ScheduleDetail nextTodo = todo2.size() > 1 ? todo2.get(1) : null;
+
+		int totalSchedule = (int) filteredAllScheduleDetails.stream()
+			.filter(sd -> sd.getScheduleStatus() != ScheduleStatus.SKIPPED)
+			.count();
+
+		int earnedStones = (int) filteredAllScheduleDetails.stream()
+			.filter(sd -> sd.getScheduleStatus() == ScheduleStatus.VERIFIED || sd.getScheduleStatus() == ScheduleStatus.COMPLETED)
+			.count();
+
+		boolean isSkippable = nextTodo != null;
+
+		TodayScheduleStatus todayScheduleStatus = TodayScheduleStatusResolver.resolve(
+			earnedStones,
+			todo,
+			filteredAllScheduleDetails,
+			earliestStoneUsedAt
+		);
+
+		if (todo == null) {
+			return TodayScheduleResponse.of(
+				null, 0, null, null, null, null,
+				totalSchedule, earnedStones,
+				todayScheduleStatus,
+				isSkippable,
+				false
+			);
+		}
+
+		int order = filteredAllScheduleDetails.indexOf(todo) + 1;
+		boolean isNowScheduleVerified = todo.getScheduleStatus() == ScheduleStatus.VERIFIED;
+
+		return TodayScheduleResponse.of(
+			todo.getId(),
+			order,
+			todo.getSchedule().getStartTime(),
+			todo.getSchedule().getEndTime(),
+			todo.getSchedule().getName(),
+			todo.getStoneType(),
+			totalSchedule,
+			earnedStones,
+			todayScheduleStatus,
+			isSkippable,
+			isNowScheduleVerified
+		);
+	}
+
+
+	@Override
+	@Transactional
 	public void skipNowSchedule(Long childId, Long scheduleDetailId) {
 		childLoadPort.findById(childId)
 			.orElseThrow(() -> new KieroException(ChildErrorCode.CHILD_NOT_FOUND));
@@ -319,5 +388,46 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			.filter(Objects::nonNull)
 			.min(LocalDateTime::compareTo)
 			.orElse(null);
+	}
+
+	private void markPassedPendingSchedulesAsFailed(List<ScheduleDetail> scheduleDetails) {
+		LocalTime now = LocalTime.now(clock);
+		scheduleDetails.stream()
+			.filter(sd -> sd.getSchedule().getEndTime().isBefore(now) && sd.getScheduleStatus() == ScheduleStatus.PENDING)
+			.forEach(sd -> sd.changeScheduleStatus(ScheduleStatus.FAILED));
+	}
+
+	private void markPassedVerifiedSchedulesAsCompleted(List<ScheduleDetail> scheduleDetails) {
+		LocalTime now = LocalTime.now(clock);
+		scheduleDetails.stream()
+			.filter(sd -> sd.getSchedule().getEndTime().isBefore(now) && sd.getScheduleStatus() == ScheduleStatus.VERIFIED)
+			.forEach(sd -> sd.changeScheduleStatus(ScheduleStatus.COMPLETED));
+	}
+
+	private List<ScheduleDetail> findTodoScheduleAndNextTodoSchedule(List<ScheduleDetail> scheduleDetails) {
+		return scheduleDetails.stream()
+			.filter(sd -> sd.getScheduleStatus() == ScheduleStatus.PENDING || sd.getScheduleStatus() == ScheduleStatus.VERIFIED)
+			.limit(2)
+			.toList();
+	}
+
+	// 오늘이 반복 요일에 해당하고, 오늘 생성되었으며, 아직 오늘자 ScheduleDetail이 생성되지 않은 반복일정들의 오늘자 ScheduleDetail을 생성하는 private method
+	private void createScheduleDetailOfTodayRecurringSchedules(LocalDate today) {
+		LocalDateTime startOfToday = today.atStartOfDay();
+		DayOfWeek todayDayOfWeek = DayOfWeek.from(today.getDayOfWeek());
+
+		List<Schedule> schedules = schedulePort.findRecurringSchedulesToGenerateTodayDetail(
+			startOfToday,
+			todayDayOfWeek,
+			today
+		);
+
+		if (schedules.isEmpty()) return;
+
+		List<ScheduleDetail> details = schedules.stream()
+			.map(schedule -> ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, schedule))
+			.toList();
+
+		detailPort.saveAll(details);
 	}
 }

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -26,6 +27,7 @@ import com.kiero.schedule.application.dto.NowScheduleCompleteEvent;
 import com.kiero.schedule.application.dto.NowScheduleCompleteRequest;
 import com.kiero.schedule.application.dto.ScheduleAddRequest;
 import com.kiero.schedule.application.dto.ScheduleCreatedEvent;
+import com.kiero.schedule.application.dto.TodayScheduleResponse;
 import com.kiero.schedule.application.exception.ScheduleErrorCode;
 import com.kiero.schedule.application.port.in.ScheduleCommandUseCase;
 import com.kiero.schedule.application.port.out.ScheduleDetailPersistencePort;
@@ -38,6 +40,8 @@ import com.kiero.schedule.domain.ScheduleRepeatDays;
 import com.kiero.schedule.domain.enums.DayOfWeek;
 import com.kiero.schedule.domain.enums.ScheduleStatus;
 import com.kiero.schedule.domain.enums.StoneType;
+import com.kiero.schedule.domain.enums.TodayScheduleStatus;
+import com.kiero.schedule.domain.policy.TodayScheduleStatusResolver;
 
 import lombok.RequiredArgsConstructor;
 
@@ -61,6 +65,9 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 	@Override
 	@Transactional
 	public void addSchedule(ScheduleAddRequest request, Long parentId, Long childId) {
+
+		LocalDate today = LocalDate.now();
+
 		Parent parent = parentLoadPort.findById(parentId)
 			.orElseThrow(() -> new KieroException(ParentErrorCode.PARENT_NOT_FOUND));
 		Child child = childLoadPort.findById(childId)
@@ -85,11 +92,21 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		Schedule saved = schedulePort.save(schedule);
 
 		if (request.isRecurring()) {
+
 			List<DayOfWeek> dayOfWeeks = dayOfWeekParser(request.dayOfWeek());
 			List<ScheduleRepeatDays> repeatDays = dayOfWeeks.stream()
 				.map(day -> ScheduleRepeatDays.create(day, saved))
 				.toList();
 			repeatDaysPort.saveAll(repeatDays);
+
+			// 당일 생성된 반복 일정 중 오늘 요일이면 scheduleDetail 생성
+			createScheduleDetailOfTodayRecurringSchedules(today);
+
+
+			// 추가된 일정의 요일에 오늘이 포함된다면 오늘 일정들의 stoneType 재계산
+			DayOfWeek todayDayOfWeek = DayOfWeek.from(today.getDayOfWeek());
+			if (dayOfWeeks.contains(todayDayOfWeek)) recalculateTodayStoneTypes(childId);
+
 		} else {
 			List<LocalDate> dates = dateParser(request.dates());
 			List<ScheduleDetail> details = dates.stream()
@@ -98,6 +115,9 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				.map(date -> ScheduleDetail.create(date, null, null, ScheduleStatus.PENDING, null, saved))
 				.toList();
 			detailPort.saveAll(details);
+
+			// 추가된 일정의 날짜가 오늘이라면 오늘 일정들의 stoneType 재계산
+			if (dates.contains(today)) recalculateTodayStoneTypes(childId);
 		}
 
 		eventPort.publish(new ScheduleCreatedEvent(childId, saved.getName()));
@@ -239,19 +259,19 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			throw new KieroException(ScheduleErrorCode.FIRE_LIT_ALREADY_COMPLETE);
 		}
 
-		List<ScheduleDetail> filteredAll = filterTodayCreatedSchedules(today, all, null);
+		List<ScheduleDetail> filteredAllScheduleDetails = filterTodayCreatedSchedules(today, all, null);
 
-		int totalSchedule = (int) filteredAll.stream()
+		int totalSchedule = (int) filteredAllScheduleDetails.stream()
 			.filter(sd -> sd.getScheduleStatus() != ScheduleStatus.SKIPPED)
 			.count();
 
-		List<StoneType> gotStones = filteredAll.stream()
+		List<StoneType> gotStones = filteredAllScheduleDetails.stream()
 			.filter(sd -> sd.getScheduleStatus() == ScheduleStatus.VERIFIED || sd.getScheduleStatus() == ScheduleStatus.COMPLETED)
 			.map(ScheduleDetail::getStoneType)
 			.toList();
 
 		LocalDateTime now = LocalDateTime.now(clock);
-		filteredAll.forEach(sd -> sd.changeStoneUsedAt(now));
+		filteredAllScheduleDetails.forEach(sd -> sd.changeStoneUsedAt(now));
 
 		int gotStonesCount = gotStones.size();
 		int earnedCoinAmount = 0;
@@ -276,7 +296,37 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			.map(schedule -> ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, schedule))
 			.toList();
 
-		detailPort.saveAll(scheduleDetails);
+		List<ScheduleDetail> savedScheduleDetails = detailPort.saveAll(scheduleDetails);
+		calculateStoneTypePerScheduleDetail(savedScheduleDetails);
+	}
+
+	private void calculateStoneTypePerScheduleDetail(List<ScheduleDetail> scheduleDetails) {
+
+		if (scheduleDetails.isEmpty()) return;
+
+		List<ScheduleDetail> orderedScheduleDetails = scheduleDetails.stream()
+			.sorted(Comparator.comparing(
+				detail -> detail.getSchedule().getStartTime()))
+			.toList();
+
+		for (ScheduleDetail sd : orderedScheduleDetails) {
+			switch (scheduleDetails.indexOf(sd) % 3) {
+				case 0 -> sd.changeStoneType(StoneType.COURAGE);
+				case 1 -> sd.changeStoneType(StoneType.GRIT);
+				case 2 -> sd.changeStoneType(StoneType.WISDOM);
+			}
+		}
+	}
+
+	private void recalculateTodayStoneTypes(Long childId) {
+		LocalDate today = LocalDate.now(clock);
+
+		List<ScheduleDetail> allScheduleDetails = detailPort.findByDateAndChildId(today, childId);
+		LocalDateTime earliestStoneUsedAt = findEarliestStoneUsedAt(allScheduleDetails);
+
+		List<ScheduleDetail> filteredAllScheduleDetails = filterTodayCreatedSchedules(today, allScheduleDetails, earliestStoneUsedAt);
+
+		calculateStoneTypePerScheduleDetail(filteredAllScheduleDetails);
 	}
 
 	private void validateAddRequest(ScheduleAddRequest request) {
@@ -368,6 +418,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		}
 	}
 
+	// 당일 생성된 일정 중, startTime과 stone 사용 여부로 유효한 일정만 필터링하는 private method
 	private List<ScheduleDetail> filterTodayCreatedSchedules(LocalDate today, List<ScheduleDetail> scheduleDetails, LocalDateTime earliestStoneUsedAt) {
 		return scheduleDetails.stream()
 			.filter(sd -> {

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -68,7 +68,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 	@Transactional
 	public void addSchedule(ScheduleAddRequest request, Long parentId, Long childId) {
 
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.now(clock);
 
 		Parent parent = parentLoadPort.findById(parentId)
 			.orElseThrow(() -> new KieroException(ParentErrorCode.PARENT_NOT_FOUND));

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
@@ -2,8 +2,6 @@ package com.kiero.schedule.application.service;
 
 import java.time.Clock;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -24,7 +22,6 @@ import com.kiero.schedule.application.dto.DefaultScheduleContentResponse;
 import com.kiero.schedule.application.dto.NormalScheduleDto;
 import com.kiero.schedule.application.dto.RecurringScheduleDto;
 import com.kiero.schedule.application.dto.ScheduleTabResponse;
-import com.kiero.schedule.application.dto.TodayScheduleResponse;
 import com.kiero.schedule.application.exception.ScheduleErrorCode;
 import com.kiero.schedule.application.port.in.ScheduleQueryUseCase;
 import com.kiero.schedule.application.port.out.ScheduleDetailPersistencePort;
@@ -33,12 +30,7 @@ import com.kiero.schedule.application.port.out.ScheduleRepeatDaysPersistencePort
 import com.kiero.schedule.domain.Schedule;
 import com.kiero.schedule.domain.ScheduleDetail;
 import com.kiero.schedule.domain.ScheduleRepeatDays;
-import com.kiero.schedule.domain.enums.DayOfWeek;
 import com.kiero.schedule.domain.enums.ScheduleColor;
-import com.kiero.schedule.domain.enums.ScheduleStatus;
-import com.kiero.schedule.domain.enums.StoneType;
-import com.kiero.schedule.domain.enums.TodayScheduleStatus;
-import com.kiero.schedule.domain.policy.TodayScheduleStatusResolver;
 
 import lombok.RequiredArgsConstructor;
 
@@ -55,79 +47,6 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 	private final ScheduleDetailPersistencePort detailPort;
 
 	private final Clock clock;
-
-	@Override
-	@Transactional
-	public TodayScheduleResponse getTodaySchedule(Long childId) {
-		LocalDate today = LocalDate.now(clock);
-
-		// 당일 생성된 반복 일정 중 오늘 요일이면 scheduleDetail 생성(수동)
-		createScheduleDetailOfTodayRecurringSchedules(today);
-
-		List<ScheduleDetail> all = detailPort.findByDateAndChildId(today, childId);
-
-		List<ScheduleDetail> pendingAndVerified = all.stream()
-			.filter(sd -> sd.getScheduleStatus() == ScheduleStatus.PENDING || sd.getScheduleStatus() == ScheduleStatus.VERIFIED)
-			.toList();
-
-		LocalDateTime earliestStoneUsedAt = findEarliestStoneUsedAt(all);
-
-		List<ScheduleDetail> filteredPendingAndVerified = filterTodayCreatedSchedules(today, pendingAndVerified, earliestStoneUsedAt);
-		List<ScheduleDetail> filteredAll = filterTodayCreatedSchedules(today, all, earliestStoneUsedAt);
-
-		markPassedPendingSchedulesAsFailed(filteredPendingAndVerified);
-		markPassedVerifiedSchedulesAsCompleted(filteredPendingAndVerified);
-
-		List<ScheduleDetail> todo2 = findTodoScheduleAndNextTodoSchedule(filteredPendingAndVerified);
-		ScheduleDetail todo = todo2.size() > 0 ? todo2.get(0) : null;
-		ScheduleDetail nextTodo = todo2.size() > 1 ? todo2.get(1) : null;
-
-		stoneTypeCalculateAndSetter(filteredAll, todo);
-
-		int totalSchedule = (int) filteredAll.stream()
-			.filter(sd -> sd.getScheduleStatus() != ScheduleStatus.SKIPPED)
-			.count();
-
-		int earnedStones = (int) filteredAll.stream()
-			.filter(sd -> sd.getScheduleStatus() == ScheduleStatus.VERIFIED || sd.getScheduleStatus() == ScheduleStatus.COMPLETED)
-			.count();
-
-		boolean isSkippable = nextTodo != null;
-
-		TodayScheduleStatus todayScheduleStatus = TodayScheduleStatusResolver.resolve(
-			earnedStones,
-			todo,
-			filteredAll,
-			earliestStoneUsedAt
-		);
-
-		if (todo == null) {
-			return TodayScheduleResponse.of(
-				null, 0, null, null, null, null,
-				totalSchedule, earnedStones,
-				todayScheduleStatus,
-				isSkippable,
-				false
-			);
-		}
-
-		int order = filteredAll.indexOf(todo) + 1;
-		boolean isNowScheduleVerified = todo.getScheduleStatus() == ScheduleStatus.VERIFIED;
-
-		return TodayScheduleResponse.of(
-			todo.getId(),
-			order,
-			todo.getSchedule().getStartTime(),
-			todo.getSchedule().getEndTime(),
-			todo.getSchedule().getName(),
-			todo.getStoneType(),
-			totalSchedule,
-			earnedStones,
-			todayScheduleStatus,
-			isSkippable,
-			isNowScheduleVerified
-		);
-	}
 
 	@Override
 	@Transactional
@@ -232,76 +151,5 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 		if (!parentChildAccessPort.existsByParentIdAndChildId(parentId, childId)) {
 			throw new KieroException(ParentErrorCode.NOT_ALLOWED_TO_CHILD);
 		}
-	}
-
-	private void markPassedPendingSchedulesAsFailed(List<ScheduleDetail> scheduleDetails) {
-		LocalTime now = LocalTime.now(clock);
-		scheduleDetails.stream()
-			.filter(sd -> sd.getSchedule().getEndTime().isBefore(now) && sd.getScheduleStatus() == ScheduleStatus.PENDING)
-			.forEach(sd -> sd.changeScheduleStatus(ScheduleStatus.FAILED));
-	}
-
-	private void markPassedVerifiedSchedulesAsCompleted(List<ScheduleDetail> scheduleDetails) {
-		LocalTime now = LocalTime.now(clock);
-		scheduleDetails.stream()
-			.filter(sd -> sd.getSchedule().getEndTime().isBefore(now) && sd.getScheduleStatus() == ScheduleStatus.VERIFIED)
-			.forEach(sd -> sd.changeScheduleStatus(ScheduleStatus.COMPLETED));
-	}
-
-	private List<ScheduleDetail> findTodoScheduleAndNextTodoSchedule(List<ScheduleDetail> scheduleDetails) {
-		return scheduleDetails.stream()
-			.filter(sd -> sd.getScheduleStatus() == ScheduleStatus.PENDING || sd.getScheduleStatus() == ScheduleStatus.VERIFIED)
-			.limit(2)
-			.toList();
-	}
-
-	private void stoneTypeCalculateAndSetter(List<ScheduleDetail> scheduleDetails, ScheduleDetail todoSchedule) {
-		if (todoSchedule == null) return;
-		switch (scheduleDetails.indexOf(todoSchedule) % 3) {
-			case 0 -> todoSchedule.changeStoneType(StoneType.COURAGE);
-			case 1 -> todoSchedule.changeStoneType(StoneType.GRIT);
-			case 2 -> todoSchedule.changeStoneType(StoneType.WISDOM);
-		}
-	}
-
-	private List<ScheduleDetail> filterTodayCreatedSchedules(LocalDate today, List<ScheduleDetail> scheduleDetails, LocalDateTime earliestStoneUsedAt) {
-		return scheduleDetails.stream()
-			.filter(sd -> {
-				Schedule schedule = sd.getSchedule();
-				LocalDateTime createdAt = schedule.getCreatedAt();
-
-				if (!createdAt.toLocalDate().equals(today)) return true;
-				if (createdAt.toLocalTime().isAfter(schedule.getStartTime())) return false;
-
-				return earliestStoneUsedAt == null || !createdAt.isAfter(earliestStoneUsedAt);
-			})
-			.toList();
-	}
-
-	private LocalDateTime findEarliestStoneUsedAt(List<ScheduleDetail> scheduleDetails) {
-		return scheduleDetails.stream()
-			.map(ScheduleDetail::getStoneUsedAt)
-			.filter(Objects::nonNull)
-			.min(LocalDateTime::compareTo)
-			.orElse(null);
-	}
-
-	private void createScheduleDetailOfTodayRecurringSchedules(LocalDate today) {
-		LocalDateTime startOfToday = today.atStartOfDay();
-		DayOfWeek todayDayOfWeek = DayOfWeek.from(today.getDayOfWeek());
-
-		List<Schedule> schedules = schedulePort.findRecurringSchedulesToGenerateTodayDetail(
-			startOfToday,
-			todayDayOfWeek,
-			today
-		);
-
-		if (schedules.isEmpty()) return;
-
-		List<ScheduleDetail> details = schedules.stream()
-			.map(schedule -> ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, schedule))
-			.toList();
-
-		detailPort.saveAll(details);
 	}
 }

--- a/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
@@ -187,6 +187,8 @@ public class ScheduleServiceTest {
 			// given
 			Long parentId = 1L;
 
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
+
 			ScheduleAddRequest req = new ScheduleAddRequest(null, null, null, null, null, null, null);
 
 			given(parentLoadPort.findById(parentId)).willReturn(Optional.empty());
@@ -203,6 +205,8 @@ public class ScheduleServiceTest {
 			// given
 			Long parentId = 1L;
 			Long childId = 1L;
+
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Parent parent = mock(Parent.class);
 
@@ -223,6 +227,8 @@ public class ScheduleServiceTest {
 			// given
 			Long parentId = 1L;
 			Long otherChildId = 100L;
+
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Parent parent = mock(Parent.class);
 			Child otherChild = mock(Child.class);
@@ -245,6 +251,8 @@ public class ScheduleServiceTest {
 			// given
 			Long parentId = 1L;
 			Long childId = 1L;
+
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Parent parent = mock(Parent.class);
 			Child child = mock(Child.class);
@@ -269,6 +277,8 @@ public class ScheduleServiceTest {
 			Long parentId = 1L;
 			Long childId = 1L;
 
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
+
 			Parent parent = mock(Parent.class);
 			Child child = mock(Child.class);
 
@@ -291,6 +301,8 @@ public class ScheduleServiceTest {
 			Long parentId = 1L;
 			Long childId = 1L;
 
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
+
 			Parent parent = mock(Parent.class);
 			Child child = mock(Child.class);
 
@@ -312,6 +324,8 @@ public class ScheduleServiceTest {
 			// given
 			Long parentId = 1L;
 			Long childId = 1L;
+
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Parent parent = mock(Parent.class);
 			Child child = mock(Child.class);

--- a/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
@@ -1152,7 +1152,7 @@ public class ScheduleServiceTest {
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of());
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.scheduleDetailId()).isNull();
@@ -1185,7 +1185,7 @@ public class ScheduleServiceTest {
 				.willReturn(List.of(sd1, sd2));
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.scheduleDetailId()).isNull();
@@ -1209,7 +1209,7 @@ public class ScheduleServiceTest {
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of());
 
 			// when
-			scheduleQueryService.getTodaySchedule(childId);
+			scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			ArgumentCaptor<List<ScheduleDetail>> captor = ArgumentCaptor.forClass(List.class);
@@ -1235,7 +1235,7 @@ public class ScheduleServiceTest {
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of());
 
 			// when
-			scheduleQueryService.getTodaySchedule(childId);
+			scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			verify(scheduleDetailPersistencePort, never()).saveAll(anyList());
@@ -1264,7 +1264,7 @@ public class ScheduleServiceTest {
 				List.of());
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.totalSchedule()).isEqualTo(1);
@@ -1288,7 +1288,7 @@ public class ScheduleServiceTest {
 			given(schedule.getStartTime()).willReturn(LocalTime.of(0, 0));
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.totalSchedule()).isEqualTo(0);
@@ -1313,7 +1313,7 @@ public class ScheduleServiceTest {
 			given(sd.getStoneUsedAt()).willReturn(LocalDateTime.of(today, LocalTime.of(0, 0)));
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.totalSchedule()).isEqualTo(0);
@@ -1342,7 +1342,7 @@ public class ScheduleServiceTest {
 			given(sd.getScheduleStatus()).willReturn(ScheduleStatus.PENDING);
 
 			// when
-			scheduleQueryService.getTodaySchedule(childId);
+			scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			verify(sd).changeScheduleStatus(ScheduleStatus.FAILED);
@@ -1371,7 +1371,7 @@ public class ScheduleServiceTest {
 			given(sd.getScheduleStatus()).willReturn(ScheduleStatus.VERIFIED);
 
 			// when
-			scheduleQueryService.getTodaySchedule(childId);
+			scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			verify(sd).changeScheduleStatus(ScheduleStatus.COMPLETED);
@@ -1402,7 +1402,7 @@ public class ScheduleServiceTest {
 			given(schedule.getEndTime()).willReturn(LocalTime.of(11, 59));
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.scheduleDetailId()).isEqualTo(1L);
@@ -1434,7 +1434,7 @@ public class ScheduleServiceTest {
 			given(schedule.getName()).willReturn("테스트 일정");
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.scheduleDetailId()).isEqualTo(scheduleDetailId);
@@ -1454,7 +1454,7 @@ public class ScheduleServiceTest {
 				.willReturn(List.of());
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.scheduleDetailId()).isNull();
@@ -1490,7 +1490,7 @@ public class ScheduleServiceTest {
 			given(s2.getEndTime()).willReturn(LocalTime.of(11, 59));
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.isSkippable()).isTrue();
@@ -1518,7 +1518,7 @@ public class ScheduleServiceTest {
 			given(s1.getEndTime()).willReturn(LocalTime.of(11, 59));
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.isSkippable()).isFalse();
@@ -1554,7 +1554,7 @@ public class ScheduleServiceTest {
 			given(sd1.getStoneType()).willAnswer(inv -> holder[0]);
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.stoneType()).isEqualTo(StoneType.COURAGE);
@@ -1607,7 +1607,7 @@ public class ScheduleServiceTest {
 			given(sd2.getStoneType()).willAnswer(inv -> holder[0]);
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.stoneType()).isEqualTo(StoneType.GRIT);
@@ -1670,7 +1670,7 @@ public class ScheduleServiceTest {
 			given(sd3.getStoneType()).willAnswer(inv -> holder[0]);
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.stoneType()).isEqualTo(StoneType.WISDOM);
@@ -1716,7 +1716,7 @@ public class ScheduleServiceTest {
 			given(s2.getEndTime()).willReturn(endTime);
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.totalSchedule()).isEqualTo(1);
@@ -1761,7 +1761,7 @@ public class ScheduleServiceTest {
 			given(s2.getEndTime()).willReturn(endTime);
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.earnedStones()).isEqualTo(1);
@@ -1806,7 +1806,7 @@ public class ScheduleServiceTest {
 			given(s2.getEndTime()).willReturn(endTime);
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.scheduleOrder()).isEqualTo(2);
@@ -1834,7 +1834,7 @@ public class ScheduleServiceTest {
 			given(schedule.getEndTime()).willReturn(LocalTime.of(11, 59));
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.isNowScheduleVerified()).isTrue();
@@ -1862,7 +1862,7 @@ public class ScheduleServiceTest {
 			given(schedule.getEndTime()).willReturn(LocalTime.of(11, 59));
 
 			// when
-			TodayScheduleResponse response = scheduleQueryService.getTodaySchedule(childId);
+			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
 
 			// then
 			assertThat(response.isNowScheduleVerified()).isFalse();

--- a/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
+++ b/src/test/java/com/kiero/schedule/service/ScheduleServiceTest.java
@@ -1148,7 +1148,7 @@ public class ScheduleServiceTest {
 		void 오늘_일정이_없으면_빈_응답_반환() {
 			// given
 			Long childId = 1L;
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of());
 
 			// when
@@ -1168,7 +1168,7 @@ public class ScheduleServiceTest {
 		void 모든_일정이_SKIPPED면_totalSchedule은_0() {
 			// given
 			Long childId = 1L;
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 			ScheduleDetail sd1 = mock(ScheduleDetail.class);
 			ScheduleDetail sd2 = mock(ScheduleDetail.class);
 
@@ -1198,40 +1198,11 @@ public class ScheduleServiceTest {
 		}
 
 		@Test
-		void 오늘_반복일정이_있으면_scheduleDetail_자동_생성() {
-			// given
-			Long childId = 1L;
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
-			Schedule schedule = mock(Schedule.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any())).willReturn(
-				List.of(schedule));
-			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of());
-
-			// when
-			scheduleCommandService.getTodaySchedule(childId);
-
-			// then
-			ArgumentCaptor<List<ScheduleDetail>> captor = ArgumentCaptor.forClass(List.class);
-			verify(scheduleDetailPersistencePort).saveAll(captor.capture());
-
-			List<ScheduleDetail> saved = captor.getValue();
-			assertThat(saved).hasSize(1);
-
-			ScheduleDetail created = saved.get(0);
-			assertThat(created.getSchedule()).isSameAs(schedule);
-			assertThat(created.getDate()).isEqualTo(today);
-			assertThat(created.getScheduleStatus()).isEqualTo(ScheduleStatus.PENDING);
-		}
-
-		@Test
 		void 오늘_반복일정이_이미_detail이_있으면_중복_생성되지_않음() {
 			// given
 			Long childId = 1L;
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any())).willReturn(
-				List.of());
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of());
 
 			// when
@@ -1245,7 +1216,7 @@ public class ScheduleServiceTest {
 		void 오늘_생성되지_않은_일정은_필터에서_제외되지_않음() {
 			// given
 			Long childId = 1L;
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule schedule = mock(Schedule.class);
 			given(schedule.getCreatedAt()).willReturn(today.minusDays(1).atStartOfDay());
@@ -1260,8 +1231,7 @@ public class ScheduleServiceTest {
 
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd));
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any())).willReturn(
-				List.of());
+
 
 			// when
 			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
@@ -1274,12 +1244,11 @@ public class ScheduleServiceTest {
 		void createdAt이_startTime_이후면_제외() {
 			// given
 			Long childId = 1L;
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 			Schedule schedule = mock(Schedule.class);
 			ScheduleDetail sd = mock(ScheduleDetail.class);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any())).willReturn(
-				List.of());
+
 
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd));
 			given(sd.getSchedule()).willReturn(schedule);
@@ -1298,12 +1267,11 @@ public class ScheduleServiceTest {
 		void 불피우기_이후에_생성된_일정은_제외() {
 			// given
 			Long childId = 1L;
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 			Schedule schedule = mock(Schedule.class);
 			ScheduleDetail sd = mock(ScheduleDetail.class);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any())).willReturn(
-				List.of());
+
 
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd));
 			given(sd.getSchedule()).willReturn(schedule);
@@ -1328,12 +1296,11 @@ public class ScheduleServiceTest {
 				today.atTime(12, 0).atZone(KST).toInstant(),
 				KST
 			);
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", afterEndClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", afterEndClock);
 			Schedule schedule = mock(Schedule.class);
 			ScheduleDetail sd = mock(ScheduleDetail.class);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any())).willReturn(
-				List.of());
+
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd));
 			given(sd.getSchedule()).willReturn(schedule);
 			given(schedule.getCreatedAt()).willReturn(LocalDateTime.of(today, LocalTime.of(0, 0)));
@@ -1357,12 +1324,11 @@ public class ScheduleServiceTest {
 				today.atTime(12, 0).atZone(KST).toInstant(),
 				KST
 			);
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", afterEndClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", afterEndClock);
 			Schedule schedule = mock(Schedule.class);
 			ScheduleDetail sd = mock(ScheduleDetail.class);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any())).willReturn(
-				List.of());
+
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd));
 			given(sd.getSchedule()).willReturn(schedule);
 			given(schedule.getCreatedAt()).willReturn(LocalDateTime.of(today, LocalTime.of(0, 0)));
@@ -1383,13 +1349,12 @@ public class ScheduleServiceTest {
 			Long childId = 1L;
 			Long scheduleDetailId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule schedule = mock(Schedule.class);
 			ScheduleDetail sd = mock(ScheduleDetail.class);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any())).willReturn(
-				List.of());
+
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd));
 
 			given(sd.getSchedule()).willReturn(schedule);
@@ -1414,13 +1379,11 @@ public class ScheduleServiceTest {
 			Long childId = 1L;
 			Long scheduleDetailId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule schedule = mock(Schedule.class);
 			ScheduleDetail sd = mock(ScheduleDetail.class);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId))
 				.willReturn(List.of(sd));
 
@@ -1446,10 +1409,8 @@ public class ScheduleServiceTest {
 			// given
 			Long childId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId))
 				.willReturn(List.of());
 
@@ -1465,7 +1426,7 @@ public class ScheduleServiceTest {
 			// given
 			Long childId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule s1 = mock(Schedule.class);
 			Schedule s2 = mock(Schedule.class);
@@ -1473,8 +1434,6 @@ public class ScheduleServiceTest {
 			ScheduleDetail sd1 = mock(ScheduleDetail.class);
 			ScheduleDetail sd2 = mock(ScheduleDetail.class);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd1, sd2));
 			given(sd1.getScheduleStatus()).willReturn(ScheduleStatus.PENDING);
 			given(sd2.getScheduleStatus()).willReturn(ScheduleStatus.PENDING);
@@ -1501,14 +1460,12 @@ public class ScheduleServiceTest {
 			// given
 			Long childId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule s1 = mock(Schedule.class);
 
 			ScheduleDetail sd1 = mock(ScheduleDetail.class);
 
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd1));
 			given(sd1.getScheduleStatus()).willReturn(ScheduleStatus.PENDING);
 			given(sd1.getSchedule()).willReturn(s1);
@@ -1525,173 +1482,17 @@ public class ScheduleServiceTest {
 		}
 
 		@Test
-		void todoSchedule_순서에_따라_StoneType_COURAGE() {
-			// given
-			Long childId = 1L;
-
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
-
-			Schedule s1 = mock(Schedule.class);
-
-			ScheduleDetail sd1 = mock(ScheduleDetail.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
-			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd1));
-			given(sd1.getScheduleStatus()).willReturn(ScheduleStatus.PENDING);
-			given(sd1.getSchedule()).willReturn(s1);
-
-			given(s1.getCreatedAt()).willReturn(LocalDateTime.of(today, LocalTime.of(0, 0)));
-			given(s1.getStartTime()).willReturn(LocalTime.of(11, 0));
-			given(s1.getEndTime()).willReturn(LocalTime.of(11, 59));
-
-			final StoneType[] holder = new StoneType[1];
-			doAnswer(inv -> {
-				holder[0] = inv.getArgument(0);
-				return null;
-			})
-				.when(sd1).changeStoneType(any(StoneType.class));
-			given(sd1.getStoneType()).willAnswer(inv -> holder[0]);
-
-			// when
-			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
-
-			// then
-			assertThat(response.stoneType()).isEqualTo(StoneType.COURAGE);
-		}
-
-		@Test
-		void todoSchedule_순서에_따라_StoneType_GRIT() {
-			// given
-			Long childId = 1L;
-
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
-
-			Schedule s1 = mock(Schedule.class);
-			Schedule s2 = mock(Schedule.class);
-
-			ScheduleDetail sd1 = mock(ScheduleDetail.class);
-			ScheduleDetail sd2 = mock(ScheduleDetail.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
-
-			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId))
-				.willReturn(List.of(sd1, sd2));
-
-			given(sd1.getScheduleStatus()).willReturn(ScheduleStatus.SKIPPED);
-			given(sd1.getSchedule()).willReturn(s1);
-			given(sd1.getStoneUsedAt()).willReturn(null);
-
-			given(sd2.getScheduleStatus()).willReturn(ScheduleStatus.PENDING);
-			given(sd2.getSchedule()).willReturn(s2);
-			given(sd2.getStoneUsedAt()).willReturn(null);
-
-			LocalDateTime createdAt = LocalDateTime.of(today, LocalTime.of(0, 0));
-			LocalTime startTime = LocalTime.of(11, 0);
-			LocalTime endTime = LocalTime.of(11, 59);
-
-			given(s1.getCreatedAt()).willReturn(createdAt);
-			given(s1.getStartTime()).willReturn(startTime);
-
-			given(s2.getCreatedAt()).willReturn(createdAt);
-			given(s2.getStartTime()).willReturn(startTime);
-			given(s2.getEndTime()).willReturn(endTime);
-
-			final StoneType[] holder = new StoneType[1];
-			doAnswer(inv -> {
-				holder[0] = inv.getArgument(0);
-				return null;
-			})
-				.when(sd2).changeStoneType(any(StoneType.class));
-			given(sd2.getStoneType()).willAnswer(inv -> holder[0]);
-
-			// when
-			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
-
-			// then
-			assertThat(response.stoneType()).isEqualTo(StoneType.GRIT);
-			verify(sd2).changeStoneType(StoneType.GRIT);
-		}
-
-		@Test
-		void todoSchedule_순서에_따라_StoneType_WISDOM() {
-			// given
-			Long childId = 1L;
-
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
-
-			Schedule s1 = mock(Schedule.class);
-			Schedule s2 = mock(Schedule.class);
-			Schedule s3 = mock(Schedule.class);
-
-			ScheduleDetail sd1 = mock(ScheduleDetail.class);
-			ScheduleDetail sd2 = mock(ScheduleDetail.class);
-			ScheduleDetail sd3 = mock(ScheduleDetail.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
-
-			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId))
-				.willReturn(List.of(sd1, sd2, sd3));
-
-			given(sd1.getScheduleStatus()).willReturn(ScheduleStatus.SKIPPED);
-			given(sd1.getSchedule()).willReturn(s1);
-			given(sd1.getStoneUsedAt()).willReturn(null);
-
-			given(sd2.getScheduleStatus()).willReturn(ScheduleStatus.SKIPPED);
-			given(sd2.getSchedule()).willReturn(s2);
-			given(sd2.getStoneUsedAt()).willReturn(null);
-
-			given(sd3.getScheduleStatus()).willReturn(ScheduleStatus.PENDING);
-			given(sd3.getSchedule()).willReturn(s3);
-			given(sd3.getStoneUsedAt()).willReturn(null);
-
-			LocalDateTime createdAt = LocalDateTime.of(today, LocalTime.of(0, 0));
-			LocalTime startTime = LocalTime.of(11, 0);
-			LocalTime endTime = LocalTime.of(11, 59);
-
-			given(s1.getCreatedAt()).willReturn(createdAt);
-			given(s1.getStartTime()).willReturn(startTime);
-
-			given(s2.getCreatedAt()).willReturn(createdAt);
-			given(s2.getStartTime()).willReturn(startTime);
-
-			given(s3.getCreatedAt()).willReturn(createdAt);
-			given(s3.getStartTime()).willReturn(startTime);
-			given(s3.getEndTime()).willReturn(endTime);
-
-			final StoneType[] holder = new StoneType[1];
-			doAnswer(inv -> {
-				holder[0] = inv.getArgument(0);
-				return null;
-			})
-				.when(sd3).changeStoneType(any(StoneType.class));
-			given(sd3.getStoneType()).willAnswer(inv -> holder[0]);
-
-			// when
-			TodayScheduleResponse response = scheduleCommandService.getTodaySchedule(childId);
-
-			// then
-			assertThat(response.stoneType()).isEqualTo(StoneType.WISDOM);
-			verify(sd3).changeStoneType(StoneType.WISDOM);
-		}
-
-		@Test
 		void SKIPPED_제외_todoSchedule_계산() {
 			// given
 			Long childId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule s1 = mock(Schedule.class);
 			Schedule s2 = mock(Schedule.class);
 
 			ScheduleDetail sd1 = mock(ScheduleDetail.class);
 			ScheduleDetail sd2 = mock(ScheduleDetail.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
 
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId))
 				.willReturn(List.of(sd1, sd2));
@@ -1727,16 +1528,13 @@ public class ScheduleServiceTest {
 			// given
 			Long childId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule s1 = mock(Schedule.class);
 			Schedule s2 = mock(Schedule.class);
 
 			ScheduleDetail sd1 = mock(ScheduleDetail.class);
 			ScheduleDetail sd2 = mock(ScheduleDetail.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
 
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId))
 				.willReturn(List.of(sd1, sd2));
@@ -1772,16 +1570,13 @@ public class ScheduleServiceTest {
 			// given
 			Long childId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule s1 = mock(Schedule.class);
 			Schedule s2 = mock(Schedule.class);
 
 			ScheduleDetail sd1 = mock(ScheduleDetail.class);
 			ScheduleDetail sd2 = mock(ScheduleDetail.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
 
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId))
 				.willReturn(List.of(sd1, sd2));
@@ -1817,14 +1612,12 @@ public class ScheduleServiceTest {
 			// given
 			Long childId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule schedule = mock(Schedule.class);
 
 			ScheduleDetail sd = mock(ScheduleDetail.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
+			
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd));
 			given(sd.getScheduleStatus()).willReturn(ScheduleStatus.VERIFIED);
 			given(sd.getSchedule()).willReturn(schedule);
@@ -1845,14 +1638,12 @@ public class ScheduleServiceTest {
 			// given
 			Long childId = 1L;
 
-			ReflectionTestUtils.setField(scheduleQueryService, "clock", fixedClock);
+			ReflectionTestUtils.setField(scheduleCommandService, "clock", fixedClock);
 
 			Schedule schedule = mock(Schedule.class);
 
 			ScheduleDetail sd = mock(ScheduleDetail.class);
-
-			given(schedulePersistencePort.findRecurringSchedulesToGenerateTodayDetail(any(), any(), any()))
-				.willReturn(List.of());
+			
 			given(scheduleDetailPersistencePort.findByDateAndChildId(today, childId)).willReturn(List.of(sd));
 			given(sd.getScheduleStatus()).willReturn(ScheduleStatus.PENDING);
 			given(sd.getSchedule()).willReturn(schedule);


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #170 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기존에는 아이가 '오늘의 여정 조회 API'를 호출하면 결과적으로 하나의 진행해야 하는(or 진행중인) 일정이 조회되며, 이 하나의 일정을 도출하는 로직에서 이 일정이 오늘 전체 일정 중 몇 번째 index에 위치해있냐에 따라 불조각 갯수를 동적으로 계산해 stoneType 필드를 업데이트하였습니다. 

스프린트에 오늘의 현황 기능이 추가되며 오늘 모든 일정에 대해 불조각 종류를 미리 계산해 놓을 필요가 있기 때문에 리팩터링을 진행하였습니다. 

매일 00시에 동작하던 기존의 scheduler에, 오늘 일자에 해당하는 일정들의 stoneType을 한 번에 계산하는 로직을 추가하였습니다. 
또 부모가 새로운 일정을 추가하면, 새로운 일정이 추가된 시점 + 일정의 startTime을 고려해 불조각이 계산되도록 로직을 추가하였습니다. 이제 반복일정 중 오늘 요일에 해당하는 일정은 '오늘의 여정 조회 API'가 호출될 때 새로 scheduleDetail이 생성되는 게 아닌, 해당 반복일정을 추가할 때 함께 scheduleDetail이 생성됩니다. 

다음 시나리오를 모두 만족합니다. 

- [x] 스케쥴러 작동 시 오늘 일정들의 stoneType이 올바른 순서로 계산되는가?
- [x] 현재 시간 이후 시간대의 당일 일정 추가 시, 올바른 순서로 stoneType이 재계산되는가?
- [x] 현재 시간 이전 시간대의 당일 일정 추가 시, 이 일정은 무시되어 stonetype이 재계산되지 않는가?


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **기능 개선**
  * 오늘 일정 조회 흐름이 명령 계층으로 명확히 이동하여 일관된 처리 경로로 제공됩니다.
  * 반복 일정의 오늘 자동 생성 동작이 강화되어 오늘 일정이 즉시 반영됩니다.
  * 오늘 일정의 돌 종류 재계산 및 상태(예정/다음예정/완료/실패) 판정 로직이 개선되었습니다.
  * 특정 날짜 기반 조회가 추가되어 날짜별 일정 확인이 가능합니다.
  * 일괄 저장 시 저장된 결과를 반환하도록 개선되어 저장 결과 확인이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->