### PR TITLE
[refactor] #173 - 자녀 재로그인 기능 추가 및 로직 수정

### DIFF
--- a/src/main/java/com/kiero/child/adapter/in/web/ChildController.java
+++ b/src/main/java/com/kiero/child/adapter/in/web/ChildController.java
@@ -12,10 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.kiero.child.application.dto.ChildLoginResponse;
 import com.kiero.child.application.dto.ChildMeResponse;
-import com.kiero.child.application.dto.ChildSignupRequest;
+import com.kiero.child.application.dto.ChildLoginRequest;
 import com.kiero.child.application.exception.ChildSuccessCode;
+import com.kiero.child.application.port.in.ChildLoginUseCase;
 import com.kiero.child.application.port.in.ChildQueryUseCase;
-import com.kiero.child.application.port.in.ChildSignupUseCase;
 import com.kiero.global.auth.annotation.CurrentMember;
 import com.kiero.global.auth.dto.CurrentAuth;
 import com.kiero.global.response.dto.SuccessResponse;
@@ -32,14 +32,14 @@ public class ChildController {
 
 	private static final String REFRESH_TOKEN = "refreshToken";
 	private static final int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
-	private final ChildSignupUseCase childSignupUseCase;
+	private final ChildLoginUseCase childLoginUseCase;
 	private final ChildQueryUseCase childQueryUseCase;
 
-	@PostMapping("/signup")
-	public ResponseEntity<SuccessResponse<ChildLoginResponse>> signup(
-		@Valid @RequestBody ChildSignupRequest request
+	@PostMapping("/login")
+	public ResponseEntity<SuccessResponse<ChildLoginResponse>> login(
+		@Valid @RequestBody ChildLoginRequest request
 	) {
-		ChildLoginResponse response = childSignupUseCase.signup(request);
+		ChildLoginResponse response = childLoginUseCase.login(request);
 		ResponseCookie cookie = ResponseCookie.from(REFRESH_TOKEN, response.refreshToken())
 			.maxAge(COOKIE_MAX_AGE)
 			.path("/")
@@ -48,10 +48,9 @@ public class ChildController {
 			.httpOnly(true)
 			.build();
 
-		return ResponseEntity
-			.status(ChildSuccessCode.SIGNUP_SUCCESS.getHttpStatus())
+		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, cookie.toString())
-			.body(SuccessResponse.of(ChildSuccessCode.SIGNUP_SUCCESS, response));
+			.body(SuccessResponse.of(ChildSuccessCode.LOGIN_SUCCESS, response));
 	}
 
 	@PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")

--- a/src/main/java/com/kiero/child/adapter/out/persistence/ChildPersistenceAdapter.java
+++ b/src/main/java/com/kiero/child/adapter/out/persistence/ChildPersistenceAdapter.java
@@ -30,4 +30,9 @@ public class ChildPersistenceAdapter implements ChildSavePort, ChildLoadPort {
 	public Optional<Child> findByIdWithLock(Long childId) {
 		return childRepository.findByIdWithLock(childId);
 	}
+
+	@Override
+	public Optional<Child> findByParentIdAndName(Long parentId, String lastName, String firstName) {
+		return childRepository.findByParentIdAndName(parentId, lastName, firstName);
+	}
 }

--- a/src/main/java/com/kiero/child/adapter/out/persistence/ChildRepository.java
+++ b/src/main/java/com/kiero/child/adapter/out/persistence/ChildRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.kiero.child.domain.Child;
+import com.kiero.parent.domain.ParentChild;
 
 import jakarta.persistence.LockModeType;
 
@@ -16,5 +17,8 @@ public interface ChildRepository extends JpaRepository<Child, Long> {
 	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT c FROM Child c WHERE c.id = :childId")
 	Optional<Child> findByIdWithLock(@Param("childId") Long childId);
+
+	@Query("SELECT pc.child FROM ParentChild pc WHERE pc.parent.id = :parentId AND pc.child.lastName = :lastName AND pc.child.firstName = :firstName")
+	Optional<Child> findByParentIdAndName(@Param("parentId") Long parentId, @Param("lastName") String lastName, @Param("firstName") String firstName);
 
 }

--- a/src/main/java/com/kiero/child/application/dto/ChildLoginRequest.java
+++ b/src/main/java/com/kiero/child/application/dto/ChildLoginRequest.java
@@ -2,7 +2,7 @@ package com.kiero.child.application.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record ChildSignupRequest(
+public record ChildLoginRequest(
         @NotBlank(message = "초대 코드를 입력해주세요.")
         String inviteCode,
 

--- a/src/main/java/com/kiero/child/application/exception/ChildSuccessCode.java
+++ b/src/main/java/com/kiero/child/application/exception/ChildSuccessCode.java
@@ -13,12 +13,8 @@ public enum ChildSuccessCode implements BaseCode {
     /*
     200 OK
     */
+    LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
     GET_INFO_SUCCESS(HttpStatus.OK, "정보 조회에 성공하였습니다."),
-
-    /*
-    201 CREATED
-    */
-    SIGNUP_SUCCESS(HttpStatus.CREATED, "가입에 성공하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kiero/child/application/port/in/ChildLoginUseCase.java
+++ b/src/main/java/com/kiero/child/application/port/in/ChildLoginUseCase.java
@@ -1,0 +1,8 @@
+package com.kiero.child.application.port.in;
+
+import com.kiero.child.application.dto.ChildLoginRequest;
+import com.kiero.child.application.dto.ChildLoginResponse;
+
+public interface ChildLoginUseCase {
+	ChildLoginResponse login(ChildLoginRequest request);
+}

--- a/src/main/java/com/kiero/child/application/port/in/ChildSignupUseCase.java
+++ b/src/main/java/com/kiero/child/application/port/in/ChildSignupUseCase.java
@@ -1,8 +1,0 @@
-package com.kiero.child.application.port.in;
-
-import com.kiero.child.application.dto.ChildLoginResponse;
-import com.kiero.child.application.dto.ChildSignupRequest;
-
-public interface ChildSignupUseCase {
-	ChildLoginResponse signup(ChildSignupRequest request);
-}

--- a/src/main/java/com/kiero/child/application/port/out/ChildLoadPort.java
+++ b/src/main/java/com/kiero/child/application/port/out/ChildLoadPort.java
@@ -7,4 +7,5 @@ import com.kiero.child.domain.Child;
 public interface ChildLoadPort {
 	Optional<Child> findById(Long childId);
 	Optional<Child> findByIdWithLock(Long childId);
+	Optional<Child> findByParentIdAndName(Long parentId, String lastName, String firstName);
 }

--- a/src/main/java/com/kiero/child/application/service/ChildService.java
+++ b/src/main/java/com/kiero/child/application/service/ChildService.java
@@ -10,10 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.kiero.child.application.dto.ChildJoinedEvent;
 import com.kiero.child.application.dto.ChildLoginResponse;
 import com.kiero.child.application.dto.ChildMeResponse;
-import com.kiero.child.application.dto.ChildSignupRequest;
+import com.kiero.child.application.dto.ChildLoginRequest;
 import com.kiero.child.application.exception.ChildErrorCode;
+import com.kiero.child.application.port.in.ChildLoginUseCase;
 import com.kiero.child.application.port.in.ChildQueryUseCase;
-import com.kiero.child.application.port.in.ChildSignupUseCase;
 import com.kiero.child.application.port.out.AuthGeneratePort;
 import com.kiero.child.application.port.out.ChildJoinedEventPort;
 import com.kiero.child.application.port.out.ChildLoadPort;
@@ -35,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class ChildService implements ChildSignupUseCase, ChildQueryUseCase {
+public class ChildService implements ChildLoginUseCase, ChildQueryUseCase {
 
 	private final InviteCodeUseCase inviteCodeUseCase;
 	private final ParentChildSaveUseCase parentChildSaveUseCase;
@@ -49,8 +49,8 @@ public class ChildService implements ChildSignupUseCase, ChildQueryUseCase {
 
 	@Override
 	@Transactional
-	public ChildLoginResponse signup(ChildSignupRequest request) {
-		log.info("Child signup started: inviteCode={}, childName={} {}",
+	public ChildLoginResponse login(ChildLoginRequest request) {
+		log.info("Child login started: inviteCode={}, childName={} {}",
 			request.inviteCode(), request.lastName(), request.firstName());
 
 		// 1. 초대 코드 검증 및 삭제 (분산 락으로 원자적 처리)
@@ -60,8 +60,6 @@ public class ChildService implements ChildSignupUseCase, ChildQueryUseCase {
 			request.firstName()
 		);
 
-		log.info("Invite code validated. Searching for parent with ID: {}", inviteCode.getParentId());
-
 		// 2. 부모 엔티티 조회
 		Parent parent = parentLoadPort.findById(inviteCode.getParentId())
 			.orElseThrow(() -> {
@@ -69,27 +67,24 @@ public class ChildService implements ChildSignupUseCase, ChildQueryUseCase {
 				return new KieroException(InvitationErrorCode.PARENT_NOT_FOUND);
 			});
 
-		log.info("Parent found: parentId={}, parentName={}", parent.getId(), parent.getName());
+		// 3. 해당 부모 하위에 동일 이름의 아이가 이미 존재하면 로그인, 없으면 신규 생성
+		Child child = childLoadPort.findByParentIdAndName(parent.getId(), request.lastName(), request.firstName())
+			.orElseGet(() -> {
+				Child newChild = Child.create(request.lastName(), request.firstName(), Role.CHILD);
+				Child savedChild = childSavePort.save(newChild);
 
-		// 3. 아이 엔티티 생성
-		Child child = Child.create(request.lastName(), request.firstName(), Role.CHILD);
-		Child savedChild = childSavePort.save(child);
+				ParentChild parentChild = ParentChild.create(parent, savedChild);
+				parentChildSaveUseCase.save(parentChild);
 
-		log.info("Child created: childId={}, childName={}", savedChild.getId(), savedChild.getFullName());
+				log.info("New child created: childId={}, childName={}", savedChild.getId(), savedChild.getFullName());
 
-		// 4. ParentChild 관계 생성
-		ParentChild parentChild = ParentChild.create(parent, savedChild);
-		parentChildSaveUseCase.save(parentChild);
+				return savedChild;
+			});
 
-		log.info("ParentChild relationship created: parentId={}, childId={}", parent.getId(), savedChild.getId());
+		// 4. 신규 가입 / 재로그인 모두 부모에게 SSE 알림 발행
+		childJoinedEventPort.publish(new ChildJoinedEvent(parent.getId(), child.getId()));
 
-		childJoinedEventPort.publish(new ChildJoinedEvent(
-			parent.getId(),
-			savedChild.getId()
-		));
-
-		// 5. 토큰 발급 및 로그인 응답 반환
-		return authGeneratePort.generateLoginResponse(savedChild);
+		return authGeneratePort.generateLoginResponse(child);
 	}
 
 	@Override

--- a/src/main/java/com/kiero/global/config/SecurityConfig.java
+++ b/src/main/java/com/kiero/global/config/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
 					"/actuator/health",
 					"/api/v1/parents/login",
 					"/api/v1/parents/login/access-token",
-					"/api/v1/children/signup",
+					"/api/v1/children/login",
 					"/api/v1/tokens/reissue/*",
 					"/api/v1/tokens/subscribe-token"
 				).permitAll()

--- a/src/main/java/com/kiero/invitation/domain/InviteCode.java
+++ b/src/main/java/com/kiero/invitation/domain/InviteCode.java
@@ -2,8 +2,6 @@ package com.kiero.invitation.domain;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
-import org.springframework.data.redis.core.index.Indexed;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -18,7 +16,6 @@ public class InviteCode {
     @Id
     private String code;
 
-    @Indexed
     private Long parentId;
 
     private String childLastName;

--- a/src/main/java/com/kiero/mission/adapter/in/web/MissionController.java
+++ b/src/main/java/com/kiero/mission/adapter/in/web/MissionController.java
@@ -24,6 +24,7 @@ import com.kiero.mission.application.dto.MissionBulkCreateRequest;
 import com.kiero.mission.application.dto.MissionCreateRequest;
 import com.kiero.mission.application.dto.MissionResponse;
 import com.kiero.mission.application.dto.MissionUpdateRequest;
+import com.kiero.mission.application.dto.MissionUpdateResponse;
 import com.kiero.mission.application.dto.MissionSuggestionRequest;
 import com.kiero.mission.application.dto.MissionSuggestionResponse;
 import com.kiero.mission.application.dto.MissionsByDateResponse;
@@ -107,12 +108,12 @@ public class MissionController {
 
     @PreAuthorize("hasAnyRole('PARENT', 'ADMIN')")
     @PatchMapping("/missions/{missionId}")
-    public ResponseEntity<SuccessResponse<MissionResponse>> updateMission(
+    public ResponseEntity<SuccessResponse<MissionUpdateResponse>> updateMission(
             @CurrentMember CurrentAuth currentAuth,
             @PathVariable Long missionId,
             @Valid @RequestBody MissionUpdateRequest request
     ) {
-        MissionResponse response = missionCommandUseCase.updateMission(currentAuth.memberId(), missionId, request);
+        MissionUpdateResponse response = missionCommandUseCase.updateMission(currentAuth.memberId(), missionId, request);
 
         return ResponseEntity.ok()
                 .body(SuccessResponse.of(MissionSuccessCode.MISSION_UPDATED, response));

--- a/src/main/java/com/kiero/mission/application/dto/MissionUpdateResponse.java
+++ b/src/main/java/com/kiero/mission/application/dto/MissionUpdateResponse.java
@@ -1,0 +1,21 @@
+package com.kiero.mission.application.dto;
+
+import java.time.LocalDate;
+
+import com.kiero.mission.domain.Mission;
+
+public record MissionUpdateResponse(
+        Long id,
+        String name,
+        int reward,
+        LocalDate dueAt
+) {
+    public static MissionUpdateResponse from(Mission mission) {
+        return new MissionUpdateResponse(
+                mission.getId(),
+                mission.getName(),
+                mission.getReward(),
+                mission.getDueAt()
+        );
+    }
+}

--- a/src/main/java/com/kiero/mission/application/port/in/MissionCommandUseCase.java
+++ b/src/main/java/com/kiero/mission/application/port/in/MissionCommandUseCase.java
@@ -6,6 +6,7 @@ import com.kiero.mission.application.dto.MissionBulkCreateRequest;
 import com.kiero.mission.application.dto.MissionCreateRequest;
 import com.kiero.mission.application.dto.MissionResponse;
 import com.kiero.mission.application.dto.MissionUpdateRequest;
+import com.kiero.mission.application.dto.MissionUpdateResponse;
 
 public interface MissionCommandUseCase {
 	MissionResponse createMission(Long parentId, Long childId, MissionCreateRequest request);
@@ -14,7 +15,7 @@ public interface MissionCommandUseCase {
 
 	MissionResponse completeMission(Long childId, Long missionId);
 
-	MissionResponse updateMission(Long parentId, Long missionId, MissionUpdateRequest request);
+	MissionUpdateResponse updateMission(Long parentId, Long missionId, MissionUpdateRequest request);
 
 	void deleteMission(Long parentId, Long missionId);
 

--- a/src/main/java/com/kiero/mission/application/service/MissionCommandService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCommandService.java
@@ -18,6 +18,7 @@ import com.kiero.mission.application.dto.MissionCreateRequest;
 import com.kiero.mission.application.dto.MissionCreatedEvent;
 import com.kiero.mission.application.dto.MissionResponse;
 import com.kiero.mission.application.dto.MissionUpdateRequest;
+import com.kiero.mission.application.dto.MissionUpdateResponse;
 import com.kiero.mission.application.exception.MissionErrorCode;
 import com.kiero.mission.application.port.in.MissionCommandUseCase;
 import com.kiero.mission.application.port.out.MissionEventPort;
@@ -143,7 +144,7 @@ public class MissionCommandService implements MissionCommandUseCase {
 
 	@Override
 	@Transactional
-	public MissionResponse updateMission(Long parentId, Long missionId, MissionUpdateRequest request) {
+	public MissionUpdateResponse updateMission(Long parentId, Long missionId, MissionUpdateRequest request) {
 		Mission mission = missionPort.findById(missionId)
 			.orElseThrow(() -> new KieroException(MissionErrorCode.MISSION_NOT_FOUND));
 
@@ -157,7 +158,7 @@ public class MissionCommandService implements MissionCommandUseCase {
 
 		mission.update(request.name(), request.reward(), request.dueAt());
 
-		return MissionResponse.from(mission);
+		return MissionUpdateResponse.from(mission);
 	}
 
 	@Override


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #173 
- closes #174

## Work Description ✏️

- 자녀가 재로그인이 가능하도록 로직을 수정했습니다.
- 기존 클래스 네이밍을 SignUp에서 Login으로 리팩토링했습니다.
- 미션 수정 응답 DTO를 추가해서 응답에 isCompleted필드를 삭제했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 초대 코드 기반 로그인 인증 방식으로 변경되었습니다.
  * 기존 자녀 계정의 조회 및 신규 자녀 등록이 통합된 로그인 흐름으로 개선되었습니다.

* **개선사항**
  * 미션 업데이트 응답 형식이 최적화되었습니다.
  * 부모 ID와 이름으로 자녀를 검색하는 쿼리 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->