### PR TITLE
[refactor] #189 - 일정 탭 조회에서 반복일정일 시 반복요일을 함께 반환하도록 수정

### DIFF
--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleOccurrenceDto.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleOccurrenceDto.java
@@ -2,10 +2,14 @@ package com.kiero.schedule.application.dto;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
+
+import com.kiero.schedule.domain.enums.DayOfWeek;
 
 public record ScheduleOccurrenceDto(
 	Long scheduleId,
 	LocalDate date,
+	List<DayOfWeek> dayOfWeek,
 	LocalTime startTime,
 	LocalTime endTime,
 	String name,

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
@@ -139,6 +139,7 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 				items.add(new ScheduleOccurrenceDto(
 					s.getId(),
 					d.getDate(),
+					List.of(),
 					s.getStartTime(),
 					s.getEndTime(),
 					s.getName(),
@@ -179,6 +180,7 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 				items.add(new ScheduleOccurrenceDto(
 					s.getId(),
 					cursor,
+					repeatDays,
 					s.getStartTime(),
 					s.getEndTime(),
 					s.getName(),


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #189

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
일정 상세정보 바가 올라왔을 때, 일정이 반복일정일 시 모든 반복요일이 보여야 합니다. 
따라서 dto를 수정해 반복요일을 포함하여 반환하도록 수정하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="871" height="598" alt="image" src="https://github.com/user-attachments/assets/96010240-d57b-4a30-b65c-9c271c20faa5" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정에 반복 요일 정보가 추가되었습니다. 각 일정 항목에는 이제 반복되는 요일 정보가 포함되며, 반복되지 않는 일정의 경우 비어있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->