### PR TITLE
[refactor] #191 - 일정 탭 조회 시 일정의 상태를 포함하여 반환, 당일 일정 추가 시 예외 상황 추가

### DIFF
--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
@@ -100,4 +100,9 @@ public class ScheduleDetailPersistenceAdapter implements ScheduleDetailPersisten
 		scheduleDetailRepository.bulkMarkVerifiedAsCompleted(today, now);
 	}
 
+	@Override
+	public boolean existsByDateAndChildIdAfterEndTime(LocalDate today, Long childId, LocalTime endTime) {
+		return scheduleDetailRepository.existsByDateAndChildIdAfterEndTime(today, childId, endTime);
+	}
+
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
@@ -128,6 +128,17 @@ public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, 
 		@Param("now") LocalTime now
 	);
 
+	@Query("""
+		select (count(sd) > 0)
+		from ScheduleDetail  sd
+		join sd.schedule s
+		where sd.date = :date
+		  and s.child.id = :childId
+		  and s.startTime >= :endTime
+		  and sd.scheduleStatus <> com.kiero.schedule.domain.enums.ScheduleStatus.PENDING
+""")
+	boolean existsByDateAndChildIdAfterEndTime(LocalDate date, Long childId, LocalTime endTime);
+
 	List<ScheduleDetail> findAllByScheduleChildIdAndDateGreaterThanEqual(Long childId, LocalDate date);
 
 	@Modifying

--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleOccurrenceDto.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleOccurrenceDto.java
@@ -5,11 +5,13 @@ import java.time.LocalTime;
 import java.util.List;
 
 import com.kiero.schedule.domain.enums.DayOfWeek;
+import com.kiero.schedule.domain.enums.ScheduleStatus;
 
 public record ScheduleOccurrenceDto(
 	Long scheduleId,
 	LocalDate date,
 	List<DayOfWeek> dayOfWeek,
+	ScheduleStatus scheduleStatus,
 	LocalTime startTime,
 	LocalTime endTime,
 	String name,

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
@@ -43,4 +43,6 @@ public interface ScheduleDetailPersistencePort {
 
 	void bulkMarkVerifiedAsCompleted(LocalDate today, LocalTime now);
 
+	boolean existsByDateAndChildIdAfterEndTime(LocalDate date, Long childId, LocalTime endTime);
+
 }

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -98,6 +98,9 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		// 오늘 아이의 불피우기 완료 여부
 		boolean isFireLitToday = scheduleDetailPersistencePort.existsStoneUsedTodayByChildIdAndDate(childId, LocalDate.now(clock));
 
+		// 요청한 일정의 종료시간 이후에 아이가 행위를 수행한 일정이 있는지 여부
+		boolean isExistsTodayNotPendingAfterEndTime = scheduleDetailPersistencePort.existsByDateAndChildIdAfterEndTime(today, childId, request.endTime());
+
 		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates());
 
 		if (request.isRecurring()) {
@@ -125,12 +128,13 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				.toList();
 			scheduleRepeatDaysPersistencePort.saveAll(repeatDays);
 
-			// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았다면
+			// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았고 아이가 미리 수행한 일정이 없다면
 			// 1) 추가된 일정의 scheduleDetail 생성
 			// 2) 오늘 일정들의 stoneType 재계산
 			// 3) 이벤트를 발행하도록 설정
 			DayOfWeek todayDayOfWeek = DayOfWeek.from(today.getDayOfWeek());
-			if (dayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday) {
+
+			if (dayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 
 				ScheduleDetail scheduleDetail = ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, saved);
 				scheduleDetailPersistencePort.save(scheduleDetail);
@@ -164,10 +168,10 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				.toList();
 			scheduleDetailPersistencePort.saveAll(details);
 
-			// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았다면
+			// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았고 아이가 미리 수행한 일정이 없다면
 			// 1) 오늘 일정들의 stoneType 재계산
 			// 2) 이벤트를 발행하도록 설정
-			if (dates.contains(today) && request.startTime().isAfter(now) && !isFireLitToday) {
+			if (dates.contains(today) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 				recalculateTodayStoneTypes(childId);
 				isEffectsToChildSchedule = true;
 			}
@@ -320,6 +324,9 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		// 오늘 아이의 불피우기 완료 여부
 		boolean isFireLitToday = scheduleDetailPersistencePort.existsStoneUsedTodayByChildIdAndDate(childId, LocalDate.now(clock));
 
+		// 요청한 일정의 종료시간 이후에 아이가 행위를 수행한 일정이 있는지 여부
+		boolean isExistsTodayNotPendingAfterEndTime = scheduleDetailPersistencePort.existsByDateAndChildIdAfterEndTime(today, childId, request.endTime());
+
 		switch (scheduleUpdateCase) {
 
 			/*
@@ -363,8 +370,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				scheduleDetailPersistencePort.saveAll(details);
 
-				// 수정 이후 일정의 날짜에 오늘이 포함되고 유효하거나, 수정하려는
-				if ((dates.contains(today) && request.startTime().isAfter(now) && !isFireLitToday) || selectedDate.isEqual(today)) {
+				// 수정 이후 일정의 날짜에 오늘이 포함되고 유효하거나, 원본 일정이 오늘이었다면
+				if ((dates.contains(today) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) || selectedDate.isEqual(today)) {
 					recalculateTodayStoneTypes(childId);
 					isEffectsToChildSchedule = true;
 				}
@@ -413,11 +420,11 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				DayOfWeek todayDayOfWeek = DayOfWeek.from(today.getDayOfWeek());
 
-				// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았다면
+				// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았고 아이가 미리 수행한 일정이 없다면
 				// 1) 추가된 일정의 scheduleDetail 생성
 				// 2) 오늘 일정들의 stoneType 재계산
 				// 3) 이벤트를 발행하도록 설정
-				if (dayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday) {
+				if (dayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 
 					ScheduleDetail scheduleDetail = ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, saved);
 					scheduleDetailPersistencePort.save(scheduleDetail);
@@ -476,11 +483,11 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				DayOfWeek todayDayOfWeek = DayOfWeek.from(today.getDayOfWeek());
 
-				// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았다면
+				// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았고 아이가 미리 수행한 일정이 없다면
 				// 1) 추가된 일정의 scheduleDetail 생성
 				// 2) 오늘 일정들의 stoneType 재계산
 				// 3) 이벤트를 발행하도록 설정
-				if (requestDayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday) {
+				if (requestDayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 
 					ScheduleDetail scheduleDetail = ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, saved);
 					scheduleDetailPersistencePort.save(scheduleDetail);
@@ -543,7 +550,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				if(originalDetail.isPresent()) {
 					originalDetail.get().changeSchedule(saved);
-					if (request.startTime().isAfter(now) && !isFireLitToday) {
+					if (request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 						recalculateTodayStoneTypes(childId);
 						isEffectsToChildSchedule = true;
 					}
@@ -592,7 +599,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				if(originalDetail.isPresent()) {
 					originalDetail.get().changeSchedule(saved);
-					if (request.startTime().isAfter(now) && !isFireLitToday) {
+					if (request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 						recalculateTodayStoneTypes(childId);
 						isEffectsToChildSchedule = true;
 					}
@@ -635,7 +642,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				scheduleDetailPersistencePort.saveAll(scheduleDetails);
 
-				if (dates.contains(today) && request.startTime().isAfter(now) && !isFireLitToday) {
+				if (dates.contains(today) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 					recalculateTodayStoneTypes(childId);
 					isEffectsToChildSchedule = true;
 				}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
@@ -91,6 +91,8 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 
 		boolean isFireLitToday = scheduleDetailPersistencePort.existsStoneUsedTodayByChildIdAndDate(childId, LocalDate.now(clock));
 
+		LocalDate today = LocalDate.now(clock);
+
 		// 반복일정 일회성 수정, 일회성 삭제 등으로 인해 무시되어야 하는 일정 집합
 		Set<DiscardKey> discardedKeys = discardedSchedulePersistencePort
 			.findAllByChildIdAndDateBetween(childId, startDate, endDate).stream()
@@ -124,6 +126,16 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 
 		List<ScheduleOccurrenceDto> items = new java.util.ArrayList<>();
 
+		// 오늘 일정들의 scheduleDetail 가져오기
+		Map<Long, ScheduleDetail> todayScheduleDetailByScheduleId = Map.of();
+		if (!today.isBefore(startDate) && !today.isAfter(endDate)) {
+			todayScheduleDetailByScheduleId = scheduleDetailPersistencePort.findByDateAndChildId(today, childId).stream()
+				.collect(Collectors.toMap(
+					sd -> sd.getSchedule().getId(),
+					sd -> sd
+				));
+		}
+
 		// 단일일정들 dto화
 		if (!normalIds.isEmpty()) {
 			List<ScheduleDetail> details = scheduleDetailPersistencePort.findAllByScheduleIdInAndDateBetween(normalIds, startDate,
@@ -131,6 +143,7 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 
 			for (ScheduleDetail d : details) {
 				Schedule s = scheduleById.get(d.getSchedule().getId());
+				ScheduleStatus todayScheduleStatus = d.getDate().isEqual(today) ? d.getScheduleStatus() : null;
 
 				// discarded 된 건 제외
 				if (discardedKeys.contains(new DiscardKey(s.getId(), d.getDate())))
@@ -140,6 +153,7 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 					s.getId(),
 					d.getDate(),
 					List.of(),
+					todayScheduleStatus,
 					s.getStartTime(),
 					s.getEndTime(),
 					s.getName(),
@@ -177,10 +191,17 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 				if (discardedKeys.contains(new DiscardKey(s.getId(), cursor)))
 					continue;
 
+				ScheduleStatus todayScheduleStatus = null;
+				if (cursor.isEqual(today)) {
+					ScheduleDetail todayDetail = todayScheduleDetailByScheduleId.get(s.getId());
+					todayScheduleStatus = todayDetail != null ? todayDetail.getScheduleStatus() : null;
+				}
+
 				items.add(new ScheduleOccurrenceDto(
 					s.getId(),
 					cursor,
 					repeatDays,
+					todayScheduleStatus,
 					s.getStartTime(),
 					s.getEndTime(),
 					s.getName(),


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #191 
- closes #192 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
당일 추가하려는 일정의 endTime 이후 일정 중, 아이가 스킵/인증 등의 행위를 진행한 일정이 존재하였다면
단일일정의 경우 일정 추가가 제한됩니다. 반복일정의 경우 일정은 추가되어 일정 탭 조회 시 확인 가능하되, 내일부터 반복일정이 유효합니다. 
이러한 예외상황에서 추가된 일정은 아이의 '오늘의 여정 조회', '지도 조회', 부모의 '오늘의 현황 조회'에서 무시되어야 합니다. 

- 단일일정 등록 제한 / 토스트메시지 노출 여부를 클라이언트가 수행할 수 있도록 하기 위해, 일정 탭 조회 시 각 일정마다 scheduleStatus를 추가적으로 반환합니다. 
- 예외 상황에서 등록된 일정이 당일에 한해 무시되도록 로직을 추가하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
일정은 추가(name = 추가된일정)되어 일정 탭 조회에서는 확인 가능하나, 이외 api에서는 없는 일정처럼 취급됩니다. 

### 일정 탭 조회 (일정이 추가된 것을 확인할 수 있음)
<img width="893" height="681" alt="image" src="https://github.com/user-attachments/assets/875299f6-e6f2-4890-818d-2f40d53e9f75" />

### 아이 오늘의 여정 조회 (추가된 일정이 무시되었기 때문에 일정 추가 전 응답에서 변화 없음)
<img width="876" height="631" alt="image" src="https://github.com/user-attachments/assets/41a84933-7ae8-4473-add2-edb666c0d7c8" />

### 부모 오늘의 현황 조회 (추가된 일정이 무시되었기 때문에 일정 추가 전 응답에서 변화 없음)
<img width="843" height="663" alt="image" src="https://github.com/user-attachments/assets/9d4be647-fe74-4d5d-80df-93edf34e7690" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일일 일정 항목의 상태 정보가 추가되어 사용자가 스케줄 상태를 더 명확하게 확인할 수 있습니다.
  * 동일 날짜의 시간 충돌을 감지하는 기능을 강화하여 예약 등록 시 더 안정적인 일정 관리가 가능합니다.

* **개선사항**
  * 오늘의 일정 조회 시 현재 상태 정보가 포함되어 더 정확한 일정 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->