### PR TITLE
[refactor] #197 - 쿠폰 조회시 최신순 정렬조건 추가

### DIFF
--- a/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponPersistenceAdapter.java
+++ b/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponPersistenceAdapter.java
@@ -19,7 +19,7 @@ public class CouponPersistenceAdapter implements CouponLoadPort, CouponPersisten
 
 	@Override
 	public List<Coupon> findAllByChildIdOrderByPriceAsc(Long childId) {
-		return couponRepository.findAllByChildIdOrderByPriceAsc(childId);
+		return couponRepository.findAllByChildIdOrderByPriceAscCreatedAtDesc(childId);
 	}
 
 	@Override

--- a/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponRepository.java
+++ b/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.kiero.coupon.domain.Coupon;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
-	List<Coupon> findAllByChildIdOrderByPriceAsc(Long childId);
+	List<Coupon> findAllByChildIdOrderByPriceAscCreatedAtDesc(Long childId);
 }

--- a/src/main/java/com/kiero/coupon/domain/Coupon.java
+++ b/src/main/java/com/kiero/coupon/domain/Coupon.java
@@ -1,6 +1,7 @@
 package com.kiero.coupon.domain;
 
 import com.kiero.child.domain.Child;
+import com.kiero.global.entity.BaseTimeEntity;
 import com.kiero.parent.domain.Parent;
 
 import jakarta.persistence.Column;
@@ -24,7 +25,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 @Table(name = CouponTableConstants.TABLE_COUPON)
-public class Coupon {
+public class Coupon extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #197 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
쿠폰 목록을 조회할 때, 기존의 가격 오름차순 정렬조건 외에도, 최신순 정렬조건이 추가되었습니다.
이에 따라서, `Coupon`엔티티는 `BaseTimeEntity`를 상속하며, 테이블에도 `createdAt`칼럼이 추가되었습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 쿠폰 정렬 순서 변경: 가격 오름차순 정렬 후 생성일 최신순으로 재정렬되도록 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->