### PR TITLE
[refactor] #199 - QA 검토사항 반영 (예외 핸들링 추가)

### DIFF
--- a/src/main/java/com/kiero/global/auth/jwt/application/exception/TokenErrorCode.java
+++ b/src/main/java/com/kiero/global/auth/jwt/application/exception/TokenErrorCode.java
@@ -15,28 +15,28 @@ public enum TokenErrorCode implements BaseCode {
 	400 BAD REQUEST
 	 */
 	AUTHENTICATION_NOT_VALID(HttpStatus.BAD_REQUEST, "잘못된 authentication token입니다"),
-	INVALID_REFRESH_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "잘못된 리프레쉬 토큰입니다"),
-	REFRESH_TOKEN_MEMBER_ID_MISMATCH_ERROR(HttpStatus.BAD_REQUEST, "리프레쉬 토큰의 사용자 정보가 일치하지 않습니다"),
-	UNSUPPORTED_REFRESH_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "지원하지 않는 리프레쉬 토큰입니다"),
-	REFRESH_TOKEN_EMPTY_ERROR(HttpStatus.BAD_REQUEST, "리프레쉬 토큰이 비어있습니다"),
-	REFRESH_TOKEN_SIGNATURE_ERROR(HttpStatus.BAD_REQUEST, "리프레쉬 토큰의 서명의 잘못 되었습니다"),
+	INVALID_JWT_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "잘못된 JWT 토큰 형식입니다"),
+	JWT_TOKEN_MEMBER_ID_MISMATCH_ERROR(HttpStatus.BAD_REQUEST, "JWT 토큰의 사용자 정보가 일치하지 않습니다"),
+	UNSUPPORTED_JWT_TOKEN_ERROR(HttpStatus.BAD_REQUEST, "지원하지 않는 토큰입니다"),
+	JWT_TOKEN_EMPTY_ERROR(HttpStatus.BAD_REQUEST, "JWT 토큰이 비어있습니다"),
+	JWT_TOKEN_SIGNATURE_ERROR(HttpStatus.BAD_REQUEST, "JWT 토큰의 서명의 잘못 되었습니다"),
 
 	/*
 	401 UNAUTHORIZED
 	 */
 	AUTHENTICATION_CODE_EXPIRED(HttpStatus.UNAUTHORIZED, "인가코드가 만료되었습니다"),
-	REFRESH_TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "리프레쉬 토큰이 만료되었습니다"),
+	JWT_TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "JWT 토큰이 만료되었습니다"),
 	INVALID_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, "유효하지 않은 authorization 헤더입니다"),
 
 	/*
 	 404 NOT FOUND
 	 */
-	REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "리프레쉬 토큰이 존재하지 않습니다"),
+	JWT_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "JWT 토큰이 존재하지 않습니다"),
 
 	/*
 		500 INTERNAL SERVER ERROR
 	 */
-	UNKNOWN_REFRESH_TOKEN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 리프레쉬 토큰 오류가 발생했습니다");
+	UNKNOWN_JWT_TOKEN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 토큰 오류가 발생했습니다");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/kiero/global/auth/jwt/application/service/AuthService.java
+++ b/src/main/java/com/kiero/global/auth/jwt/application/service/AuthService.java
@@ -114,12 +114,12 @@ public class AuthService {
 
 		if (!validationType.equals(JwtValidationType.VALID_JWT)) {
 			throw switch (validationType) {
-				case EXPIRED_JWT_TOKEN -> new KieroException(TokenErrorCode.REFRESH_TOKEN_EXPIRED_ERROR);
-				case INVALID_JWT_TOKEN -> new KieroException(TokenErrorCode.INVALID_REFRESH_TOKEN_ERROR);
-				case INVALID_JWT_SIGNATURE -> new KieroException(TokenErrorCode.REFRESH_TOKEN_SIGNATURE_ERROR);
-				case UNSUPPORTED_JWT_TOKEN -> new KieroException(TokenErrorCode.UNSUPPORTED_REFRESH_TOKEN_ERROR);
-				case EMPTY_JWT -> new KieroException(TokenErrorCode.REFRESH_TOKEN_EMPTY_ERROR);
-				default -> new KieroException(TokenErrorCode.UNKNOWN_REFRESH_TOKEN_ERROR);
+				case EXPIRED_JWT_TOKEN -> new KieroException(TokenErrorCode.JWT_TOKEN_EXPIRED_ERROR);
+				case INVALID_JWT_TOKEN -> new KieroException(TokenErrorCode.INVALID_JWT_TOKEN_ERROR);
+				case INVALID_JWT_SIGNATURE -> new KieroException(TokenErrorCode.JWT_TOKEN_SIGNATURE_ERROR);
+				case UNSUPPORTED_JWT_TOKEN -> new KieroException(TokenErrorCode.UNSUPPORTED_JWT_TOKEN_ERROR);
+				case EMPTY_JWT -> new KieroException(TokenErrorCode.JWT_TOKEN_EMPTY_ERROR);
+				default -> new KieroException(TokenErrorCode.UNKNOWN_JWT_TOKEN_ERROR);
 			};
 		}
 	}
@@ -151,7 +151,7 @@ public class AuthService {
 
 		if (!refreshToken.equals(storedRefreshToken)) {
 			log.error("MemberId mismatch: token does not match the stored refresh token");
-			throw new KieroException(TokenErrorCode.REFRESH_TOKEN_MEMBER_ID_MISMATCH_ERROR);
+			throw new KieroException(TokenErrorCode.JWT_TOKEN_MEMBER_ID_MISMATCH_ERROR);
 		}
 	}
 

--- a/src/main/java/com/kiero/global/auth/jwt/infrastructure/persistence/redis/TokenService.java
+++ b/src/main/java/com/kiero/global/auth/jwt/infrastructure/persistence/redis/TokenService.java
@@ -30,7 +30,7 @@ public class TokenService {
 		String key = TokenKeyGenerator.refreshKey(memberId, role);
 		return tokenRepository.findById(key)
 			.map(Token::getRefreshToken)
-			.orElseThrow(() -> new KieroException(TokenErrorCode.REFRESH_TOKEN_NOT_FOUND));
+			.orElseThrow(() -> new KieroException(TokenErrorCode.JWT_TOKEN_NOT_FOUND));
 	}
 
 	@Transactional
@@ -39,7 +39,7 @@ public class TokenService {
 		Token token = tokenRepository.findById(key)
 			.orElseThrow(() -> {
 				log.error("No refresh token found in Redis for memberId: {}", memberId);
-				return new KieroException(TokenErrorCode.REFRESH_TOKEN_NOT_FOUND);
+				return new KieroException(TokenErrorCode.JWT_TOKEN_NOT_FOUND);
 			});
 		tokenRepository.delete(token);
 		log.info("Successfully deleted refresh token for memberId: {}", memberId);

--- a/src/main/java/com/kiero/global/auth/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/kiero/global/auth/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.kiero.global.auth.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kiero.global.auth.jwt.application.exception.TokenErrorCode;
+import com.kiero.global.response.dto.ErrorResponse;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException authException
+	) throws IOException {
+
+		TokenErrorCode errorCode = TokenErrorCode.JWT_TOKEN_EMPTY_ERROR;
+
+		response.setStatus(errorCode.getHttpStatus().value());
+		response.setContentType("application/json;charset=UTF-8");
+		response.getWriter().write(
+			objectMapper.writeValueAsString(ErrorResponse.of(errorCode))
+		);
+	}
+}

--- a/src/main/java/com/kiero/global/auth/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/kiero/global/auth/security/CustomAuthenticationEntryPoint.java
@@ -28,7 +28,11 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 		AuthenticationException authException
 	) throws IOException {
 
-		TokenErrorCode errorCode = TokenErrorCode.JWT_TOKEN_EMPTY_ERROR;
+		String authorizationHeader = request.getHeader("Authorization");
+
+		TokenErrorCode errorCode = (authorizationHeader != null && !authorizationHeader.startsWith("Bearer "))
+			? TokenErrorCode.INVALID_AUTHORIZATION_HEADER
+			: TokenErrorCode.JWT_TOKEN_EMPTY_ERROR;
 
 		response.setStatus(errorCode.getHttpStatus().value());
 		response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/kiero/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kiero/global/auth/security/JwtAuthenticationFilter.java
@@ -12,11 +12,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kiero.global.auth.enums.Role;
+import com.kiero.global.auth.jwt.application.exception.TokenErrorCode;
 import com.kiero.global.auth.jwt.infrastructure.JwtTokenProvider;
 import com.kiero.global.auth.jwt.infrastructure.JwtValidationType;
 import com.kiero.global.exception.KieroException;
 import com.kiero.global.response.code.ErrorCode;
+import com.kiero.global.response.dto.ErrorResponse;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -78,12 +81,26 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		SecurityContextHolder.getContext().setAuthentication(authentication);
 	}
 
-	private void handleInvalidToken(JwtValidationType validationType, HttpServletResponse response) {
-		if (validationType == JwtValidationType.EXPIRED_JWT_TOKEN) {
-			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-		} else {
-			response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-		}
+	private void handleInvalidToken(JwtValidationType validationType, HttpServletResponse response) throws IOException {
+
+		TokenErrorCode errorCode = switch (validationType) {
+			case EXPIRED_JWT_TOKEN -> TokenErrorCode.JWT_TOKEN_EXPIRED_ERROR;
+			case INVALID_JWT_TOKEN -> TokenErrorCode.INVALID_JWT_TOKEN_ERROR;
+			case INVALID_JWT_SIGNATURE -> TokenErrorCode.JWT_TOKEN_SIGNATURE_ERROR;
+			case UNSUPPORTED_JWT_TOKEN -> TokenErrorCode.UNSUPPORTED_JWT_TOKEN_ERROR;
+			case EMPTY_JWT -> TokenErrorCode.JWT_TOKEN_EMPTY_ERROR;
+			default -> TokenErrorCode.UNKNOWN_JWT_TOKEN_ERROR;
+		};
+
+		response.setStatus(errorCode.getHttpStatus().value());
+		response.setContentType("application/json;charset=UTF-8");
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		response.getWriter().write(
+			objectMapper.writeValueAsString(
+				ErrorResponse.of(errorCode)
+			)
+		);
 	}
 
 	private String getJwtFromRequest(HttpServletRequest request) {

--- a/src/main/java/com/kiero/global/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kiero/global/auth/security/JwtAuthenticationFilter.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final ObjectMapper objectMapper;
 
 	@Override
 	protected void doFilterInternal(
@@ -95,7 +96,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		response.setStatus(errorCode.getHttpStatus().value());
 		response.setContentType("application/json;charset=UTF-8");
 
-		ObjectMapper objectMapper = new ObjectMapper();
 		response.getWriter().write(
 			objectMapper.writeValueAsString(
 				ErrorResponse.of(errorCode)

--- a/src/main/java/com/kiero/global/config/SecurityConfig.java
+++ b/src/main/java/com/kiero/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.kiero.global.auth.security.CustomAuthenticationEntryPoint;
 import com.kiero.global.auth.security.JwtAuthenticationFilter;
 
 import jakarta.servlet.DispatcherType;
@@ -22,7 +23,8 @@ public class SecurityConfig {
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
 	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+	public SecurityFilterChain securityFilterChain(HttpSecurity http,
+		CustomAuthenticationEntryPoint customAuthenticationEntryPoint) throws Exception {
 		http
 			.csrf(csrf -> csrf.disable())
 			.formLogin(form -> form.disable())
@@ -30,6 +32,8 @@ public class SecurityConfig {
 			.sessionManagement(sm ->
 				sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(customAuthenticationEntryPoint))
 			.authorizeHttpRequests(auth -> auth
 				.dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
 				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()

--- a/src/main/java/com/kiero/global/resolver/CurrentMemberArgumentResolver.java
+++ b/src/main/java/com/kiero/global/resolver/CurrentMemberArgumentResolver.java
@@ -38,7 +38,7 @@ public class CurrentMemberArgumentResolver implements HandlerMethodArgumentResol
 			.map(a-> a.replace("ROLE_", ""))
 			.map(Role::valueOf)
 			.findFirst()
-			.orElseThrow(()-> new KieroException(TokenErrorCode.INVALID_REFRESH_TOKEN_ERROR));
+			.orElseThrow(()-> new KieroException(TokenErrorCode.INVALID_JWT_TOKEN_ERROR));
 		return new CurrentAuth(memberId, role);
 	}
 

--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleAddRequest.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleAddRequest.java
@@ -11,10 +11,10 @@ import jakarta.validation.constraints.Size;
 
 public record ScheduleAddRequest(
 	@Size(max = 10) @NotNull @NotEmpty String name,
-	@NotNull @NotEmpty Boolean isRecurring,
-	@NotNull @NotEmpty LocalTime startTime,
-	@NotNull @NotEmpty LocalTime endTime,
-	@NotNull @NotEmpty ScheduleColor scheduleColor,
+	@NotNull Boolean isRecurring,
+	@NotNull LocalTime startTime,
+	@NotNull LocalTime endTime,
+	@NotNull ScheduleColor scheduleColor,
 	LocalDate firstOrderDate,
 	String dayOfWeek,
 	String dates

--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleAddRequest.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleAddRequest.java
@@ -5,15 +5,16 @@ import java.time.LocalTime;
 
 import com.kiero.schedule.domain.enums.ScheduleColor;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record ScheduleAddRequest(
-	@Size(max = 10) @NotNull String name,
-	@NotNull Boolean isRecurring,
-	@NotNull LocalTime startTime,
-	@NotNull LocalTime endTime,
-	@NotNull ScheduleColor scheduleColor,
+	@Size(max = 10) @NotNull @NotEmpty String name,
+	@NotNull @NotEmpty Boolean isRecurring,
+	@NotNull @NotEmpty LocalTime startTime,
+	@NotNull @NotEmpty LocalTime endTime,
+	@NotNull @NotEmpty ScheduleColor scheduleColor,
 	LocalDate firstOrderDate,
 	String dayOfWeek,
 	String dates

--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleModifyRequest.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleModifyRequest.java
@@ -4,15 +4,16 @@ import java.time.LocalTime;
 
 import com.kiero.schedule.domain.enums.ScheduleColor;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record ScheduleModifyRequest(
-	@Size(max = 10) @NotNull String name,
-	@NotNull Boolean isRecurring,
-	@NotNull LocalTime startTime,
-	@NotNull LocalTime endTime,
-	@NotNull ScheduleColor scheduleColor,
+	@Size(max = 10) @NotNull @NotEmpty String name,
+	@NotNull @NotEmpty Boolean isRecurring,
+	@NotNull @NotEmpty LocalTime startTime,
+	@NotNull @NotEmpty LocalTime endTime,
+	@NotNull @NotEmpty ScheduleColor scheduleColor,
 	String dayOfWeek,
 	String dates,
 	Boolean isIncludeFollowing

--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleModifyRequest.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleModifyRequest.java
@@ -10,10 +10,10 @@ import jakarta.validation.constraints.Size;
 
 public record ScheduleModifyRequest(
 	@Size(max = 10) @NotNull @NotEmpty String name,
-	@NotNull @NotEmpty Boolean isRecurring,
-	@NotNull @NotEmpty LocalTime startTime,
-	@NotNull @NotEmpty LocalTime endTime,
-	@NotNull @NotEmpty ScheduleColor scheduleColor,
+	@NotNull Boolean isRecurring,
+	@NotNull LocalTime startTime,
+	@NotNull LocalTime endTime,
+	@NotNull ScheduleColor scheduleColor,
 	String dayOfWeek,
 	String dates,
 	Boolean isIncludeFollowing

--- a/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
@@ -27,6 +27,10 @@ public enum ScheduleErrorCode implements BaseCode {
 	DAY_OF_WEEK_CANNOT_BE_MODIFIED(HttpStatus.BAD_REQUEST, "'이후 일정 포함', '이번 일정만' 조건 선택 시 요일은 수정될 수 없습니다."),
 	IS_INCLUDE_FOLLOWING_IS_REQUIRED(HttpStatus.BAD_REQUEST, "반복일정을 삭제할 경우, body에 '이후 일정 포함 여부'를 포함해야 합니다."),
 	SCHEDULE_CANNOT_BE_DELETED(HttpStatus.BAD_REQUEST, "아이가 이미 넘어가기, 인증 등의 행위를 수행하였거나 일정 시각이 지난 일정은 삭제할 수 없습니다."),
+	INVALID_WEEK_START_DATE(HttpStatus.BAD_REQUEST, "일정 조회 시작 날짜는 월요일이어야 합니다."),
+	INVALID_WEEK_END_DATE(HttpStatus.BAD_REQUEST, "일정 조회 종료 날짜는 일요일이어야 합니다."),
+	INVALID_SCHEDULE_RANGE(HttpStatus.BAD_REQUEST, "현재로부터 전후 12주의 일정만 조회할 수 있습니다."),
+
 	/*
 	403 FORBIDDEN
 	 */

--- a/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
@@ -26,7 +26,7 @@ public enum ScheduleErrorCode implements BaseCode {
 	PAST_SCHEDULE_CANNOT_BE_MODIFIED(HttpStatus.BAD_REQUEST, "과거의 일정은 수정될 수 없습니다."),
 	DAY_OF_WEEK_CANNOT_BE_MODIFIED(HttpStatus.BAD_REQUEST, "'이후 일정 포함', '이번 일정만' 조건 선택 시 요일은 수정될 수 없습니다."),
 	IS_INCLUDE_FOLLOWING_IS_REQUIRED(HttpStatus.BAD_REQUEST, "반복일정을 삭제할 경우, body에 '이후 일정 포함 여부'를 포함해야 합니다."),
-	SCHEDULE_CANNOT_BE_DELETED(HttpStatus.BAD_REQUEST, "아이가 이미 넘어가기, 인증 등의 행위를 수행하였거나 일정 시각이 지난 일정은 삭제할 수 없습니다."),
+	SCHEDULE_CANNOT_BE_MANIPULATED(HttpStatus.BAD_REQUEST, "아이가 이미 넘어가기, 인증 등의 행위를 수행하였거나 일정 시각이 지난 일정은 조작할 수 없습니다."),
 	INVALID_WEEK_START_DATE(HttpStatus.BAD_REQUEST, "일정 조회 시작 날짜는 월요일이어야 합니다."),
 	INVALID_WEEK_END_DATE(HttpStatus.BAD_REQUEST, "일정 조회 종료 날짜는 일요일이어야 합니다."),
 	INVALID_SCHEDULE_RANGE(HttpStatus.BAD_REQUEST, "현재로부터 전후 12주의 일정만 조회할 수 있습니다."),

--- a/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
@@ -30,6 +30,7 @@ public enum ScheduleErrorCode implements BaseCode {
 	INVALID_WEEK_START_DATE(HttpStatus.BAD_REQUEST, "일정 조회 시작 날짜는 월요일이어야 합니다."),
 	INVALID_WEEK_END_DATE(HttpStatus.BAD_REQUEST, "일정 조회 종료 날짜는 일요일이어야 합니다."),
 	INVALID_SCHEDULE_RANGE(HttpStatus.BAD_REQUEST, "현재로부터 전후 12주의 일정만 조회할 수 있습니다."),
+	INVALID_TIME_DURATION(HttpStatus.BAD_REQUEST, "일정 시작 시간은 일정 종료 시간의 이전이어야 합니다."),
 
 	/*
 	403 FORBIDDEN

--- a/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
@@ -32,6 +32,8 @@ public enum ScheduleErrorCode implements BaseCode {
 	INVALID_SCHEDULE_RANGE(HttpStatus.BAD_REQUEST, "현재로부터 전후 12주의 일정만 조회할 수 있습니다."),
 	INVALID_TIME_DURATION(HttpStatus.BAD_REQUEST, "일정 시작 시간은 일정 종료 시간의 이전이어야 합니다."),
 	SCHEDULE_IN_PAST(HttpStatus.BAD_REQUEST, "오늘의 단일 일정의 경우, 현재 이전 시간대로 조작될 수 없습니다."),
+	SCHEDULE_NOT_MANIPULATED_WHEN_FIRE_LIT(HttpStatus.BAD_REQUEST, "오늘의 불 피우기가 완료되었을 때, 오늘 단일 일정을 조작할 수 없습니다."),
+	SCHEDULE_NOT_MANIPULATED_WHEN_AFTER_SCHEDULE_NOT_PENDING(HttpStatus.BAD_REQUEST, "등록하려는 일정의 이후 일정 중 아이가 행위를 진행한 일정이 있다면 등록 불가능합니다."),
 
 	/*
 	403 FORBIDDEN

--- a/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
+++ b/src/main/java/com/kiero/schedule/application/exception/ScheduleErrorCode.java
@@ -31,6 +31,7 @@ public enum ScheduleErrorCode implements BaseCode {
 	INVALID_WEEK_END_DATE(HttpStatus.BAD_REQUEST, "일정 조회 종료 날짜는 일요일이어야 합니다."),
 	INVALID_SCHEDULE_RANGE(HttpStatus.BAD_REQUEST, "현재로부터 전후 12주의 일정만 조회할 수 있습니다."),
 	INVALID_TIME_DURATION(HttpStatus.BAD_REQUEST, "일정 시작 시간은 일정 종료 시간의 이전이어야 합니다."),
+	SCHEDULE_IN_PAST(HttpStatus.BAD_REQUEST, "오늘의 단일 일정의 경우, 현재 이전 시간대로 조작될 수 없습니다."),
 
 	/*
 	403 FORBIDDEN

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -101,7 +101,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		// 요청한 일정의 종료시간 이후에 아이가 행위를 수행한 일정이 있는지 여부
 		boolean isExistsTodayNotPendingAfterEndTime = scheduleDetailPersistencePort.existsByDateAndChildIdAfterEndTime(today, childId, request.endTime());
 
-		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates());
+		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime());
 
 		if (request.isRecurring()) {
 
@@ -307,7 +307,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			throw new KieroException(ScheduleErrorCode.PAST_SCHEDULE_CANNOT_BE_MODIFIED);
 		}
 
-		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates());
+		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime());
 
 		Schedule originalSchedule = schedulePersistencePort.findById(scheduleId)
 			.orElseThrow(() -> new KieroException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
@@ -776,7 +776,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		}
 	}
 
-	private void validateAddAndUpdateRequest(boolean isRecurring, String dayOfWeek, String dates) {
+	private void validateAddAndUpdateRequest(boolean isRecurring, String dayOfWeek, String dates, LocalTime startTime, LocalTime endTime) {
 		if (isRecurring && (dayOfWeek == null || dayOfWeek.isEmpty())) {
 			throw new KieroException(ScheduleErrorCode.DAY_OF_WEEK_NOT_NULLABLE_WHEN_IS_RECURRING_IS_TRUE);
 		}
@@ -785,6 +785,9 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		}
 		if (dayOfWeek != null && dates != null) {
 			throw new KieroException(ScheduleErrorCode.DAY_OF_WEEK_XOR_DATE_REQUIRED);
+		}
+		if (!startTime.isBefore(endTime)) {
+			throw new KieroException(ScheduleErrorCode.INVALID_TIME_DURATION);
 		}
 	}
 

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -102,7 +102,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		// 요청한 일정의 종료시간 이후에 아이가 행위를 수행한 일정이 있는지 여부
 		boolean isExistsTodayNotPendingAfterEndTime = scheduleDetailPersistencePort.existsByDateAndChildIdAfterEndTime(today, childId, request.endTime());
 
-		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime());
+		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime(), isFireLitToday, isExistsTodayNotPendingAfterEndTime);
 
 		if (request.isRecurring()) {
 
@@ -308,18 +308,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			throw new KieroException(ScheduleErrorCode.PAST_SCHEDULE_CANNOT_BE_MODIFIED);
 		}
 
-		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime());
-
 		Schedule originalSchedule = schedulePersistencePort.findById(scheduleId)
 			.orElseThrow(() -> new KieroException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
-
-		if (!parentId.equals(originalSchedule.getParent().getId())) {
-			throw new KieroException(ScheduleErrorCode.SCHEDULE_ACCESS_DENIED);
-		}
-
-		boolean isEffectsToChildSchedule = false;
-
-		ScheduleUpdateCase scheduleUpdateCase = scheduleUpdateCaseResolver(originalSchedule, request);
 
 		Long childId = originalSchedule.getChild().getId();
 
@@ -328,6 +318,16 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 		// 요청한 일정의 종료시간 이후에 아이가 행위를 수행한 일정이 있는지 여부
 		boolean isExistsTodayNotPendingAfterEndTime = scheduleDetailPersistencePort.existsByDateAndChildIdAfterEndTime(today, childId, request.endTime());
+
+		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime(), isFireLitToday, isExistsTodayNotPendingAfterEndTime);
+
+		if (!parentId.equals(originalSchedule.getParent().getId())) {
+			throw new KieroException(ScheduleErrorCode.SCHEDULE_ACCESS_DENIED);
+		}
+
+		boolean isEffectsToChildSchedule = false;
+
+		ScheduleUpdateCase scheduleUpdateCase = scheduleUpdateCaseResolver(originalSchedule, request);
 
 		switch (scheduleUpdateCase) {
 
@@ -777,7 +777,12 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		}
 	}
 
-	private void validateAddAndUpdateRequest(boolean isRecurring, String dayOfWeek, String dates, LocalTime startTime, LocalTime endTime) {
+	private void validateAddAndUpdateRequest(boolean isRecurring, String dayOfWeek, String dates, LocalTime startTime, LocalTime endTime, boolean isFireLitToday, boolean isExistsTodayNotPendingAfterEndTime) {
+
+		LocalDate today = LocalDate.now();
+		LocalTime now = LocalTime.now();
+		List<LocalDate> requestDates = dates == null ? null : dateParser(dates);
+
 		if (isRecurring && (dayOfWeek == null || dayOfWeek.isEmpty())) {
 			throw new KieroException(ScheduleErrorCode.DAY_OF_WEEK_NOT_NULLABLE_WHEN_IS_RECURRING_IS_TRUE);
 		}
@@ -790,12 +795,14 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		if (!startTime.isBefore(endTime)) {
 			throw new KieroException(ScheduleErrorCode.INVALID_TIME_DURATION);
 		}
-		if (dates != null) {
-			LocalDate today = LocalDate.now();
-			LocalTime now = LocalTime.now();
-			List<LocalDate> requestDates = dateParser(dates);
-
-			if (requestDates.contains(today) && !now.isBefore(startTime)) {
+		if (dates != null && requestDates.contains(today)) {
+			if (isFireLitToday) {
+				throw new KieroException(ScheduleErrorCode.SCHEDULE_NOT_MANIPULATED_WHEN_FIRE_LIT);
+			}
+			if (isExistsTodayNotPendingAfterEndTime) {
+				throw new KieroException(ScheduleErrorCode.SCHEDULE_NOT_MANIPULATED_WHEN_AFTER_SCHEDULE_NOT_PENDING);
+			}
+			if (!now.isBefore(startTime)) {
 				throw new KieroException(ScheduleErrorCode.SCHEDULE_IN_PAST);
 			}
 		}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -321,6 +321,15 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime(), isFireLitToday, isExistsTodayNotPendingAfterEndTime);
 
+		// 오늘 일정을 수정하려고 할 때, 수정하려는 일정 상태가 PENDING이 아니거나 이미 시작된 일정이라면 예외
+		if (selectedDate.isEqual(today)) {
+			ScheduleDetail originalTodayDetail = scheduleDetailPersistencePort.findByScheduleIdAndDate(scheduleId, today)
+				.orElseThrow(()-> new KieroException(ScheduleErrorCode.INTERNAL_SERVER_ERROR));
+			if (originalTodayDetail.getScheduleStatus() != ScheduleStatus.PENDING || !originalSchedule.getStartTime().isAfter(now)) {
+				throw new KieroException(ScheduleErrorCode.SCHEDULE_CANNOT_BE_MANIPULATED);
+			}
+		}
+
 		if (!parentId.equals(originalSchedule.getParent().getId())) {
 			throw new KieroException(ScheduleErrorCode.SCHEDULE_ACCESS_DENIED);
 		}
@@ -708,7 +717,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 					recalculateTodayStoneTypes(childId);
 				}
 				else {
-					throw new KieroException(ScheduleErrorCode.SCHEDULE_CANNOT_BE_DELETED);
+					throw new KieroException(ScheduleErrorCode.SCHEDULE_CANNOT_BE_MANIPULATED);
 				}
 
 
@@ -727,7 +736,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 					recalculateTodayStoneTypes(childId);
 				}
 				else {
-					throw new KieroException(ScheduleErrorCode.SCHEDULE_CANNOT_BE_DELETED);
+					throw new KieroException(ScheduleErrorCode.SCHEDULE_CANNOT_BE_MANIPULATED);
 				}
 			}
 		}
@@ -744,7 +753,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				recalculateTodayStoneTypes(childId);
 			}
 			else {
-				throw new KieroException(ScheduleErrorCode.SCHEDULE_CANNOT_BE_DELETED);
+				throw new KieroException(ScheduleErrorCode.SCHEDULE_CANNOT_BE_MANIPULATED);
 			}
 
 		}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -310,6 +310,10 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		Schedule originalSchedule = schedulePersistencePort.findById(scheduleId)
 			.orElseThrow(() -> new KieroException(ScheduleErrorCode.SCHEDULE_NOT_FOUND));
 
+		if (!parentId.equals(originalSchedule.getParent().getId())) {
+			throw new KieroException(ScheduleErrorCode.SCHEDULE_ACCESS_DENIED);
+		}
+
 		Long childId = originalSchedule.getChild().getId();
 
 		// 오늘 아이의 불피우기 완료 여부
@@ -328,10 +332,6 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		}
 
 		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime(), isFireLitToday, isExistsTodayNotPendingAfterEndTime);
-
-		if (!parentId.equals(originalSchedule.getParent().getId())) {
-			throw new KieroException(ScheduleErrorCode.SCHEDULE_ACCESS_DENIED);
-		}
 
 		boolean isEffectsToChildSchedule = false;
 

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -791,8 +790,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 	private void validateAddAndUpdateRequest(boolean isRecurring, String dayOfWeek, String dates, LocalTime startTime, LocalTime endTime, boolean isFireLitToday, boolean isExistsTodayNotPendingAfterEndTime) {
 
-		LocalDate today = LocalDate.now();
-		LocalTime now = LocalTime.now();
+		LocalDate today = LocalDate.now(clock);
+		LocalTime now = LocalTime.now(clock);
 		List<LocalDate> requestDates = dates == null ? null : dateParser(dates);
 
 		// 반복일정일 때 dayOfWeek 필드가 비어있으면 예외

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -319,8 +319,6 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		// 요청한 일정의 종료시간 이후에 아이가 행위를 수행한 일정이 있는지 여부
 		boolean isExistsTodayNotPendingAfterEndTime = scheduleDetailPersistencePort.existsByDateAndChildIdAfterEndTime(today, childId, request.endTime());
 
-		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime(), isFireLitToday, isExistsTodayNotPendingAfterEndTime);
-
 		// 오늘 일정을 수정하려고 할 때, 수정하려는 일정 상태가 PENDING이 아니거나 이미 시작된 일정이라면 예외
 		if (selectedDate.isEqual(today)) {
 			ScheduleDetail originalTodayDetail = scheduleDetailPersistencePort.findByScheduleIdAndDate(scheduleId, today)
@@ -329,6 +327,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				throw new KieroException(ScheduleErrorCode.SCHEDULE_CANNOT_BE_MANIPULATED);
 			}
 		}
+
+		validateAddAndUpdateRequest(request.isRecurring(), request.dayOfWeek(), request.dates(), request.startTime(), request.endTime(), isFireLitToday, isExistsTodayNotPendingAfterEndTime);
 
 		if (!parentId.equals(originalSchedule.getParent().getId())) {
 			throw new KieroException(ScheduleErrorCode.SCHEDULE_ACCESS_DENIED);
@@ -693,6 +693,9 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		boolean isPending = hasDetail && scheduleDetail.get().getScheduleStatus() == ScheduleStatus.PENDING;
 		boolean isBeforeStart = originalSchedule.getStartTime().isAfter(now);
 
+		// 삭제하려는 일정의 종료시간 이후에 아이가 행위를 수행한 일정이 있는지 여부
+		boolean isExistsTodayNotPendingAfterEndTime = scheduleDetailPersistencePort.existsByDateAndChildIdAfterEndTime(today, childId, originalSchedule.getEndTime());
+
 		// 삭제하려는 일정이 반복일정일 경우
 		if (originalSchedule.isRecurring()) {
 			if (request == null || request.isIncludeFollowing() == null)
@@ -708,7 +711,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				if ( !isToday ) {
 					originalSchedule.changeRepeatEndDate(repeatEndDate);
 				}
-				else if ( hasDetail && isPending && isBeforeStart ) {
+				else if ( hasDetail && isPending && isBeforeStart && !isExistsTodayNotPendingAfterEndTime) {
 					originalSchedule.changeRepeatEndDate(repeatEndDate);
 
 					scheduleDetailPersistencePort.deleteScheduleDetail(scheduleDetail.get());
@@ -726,7 +729,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 					DiscardedSchedule discardedSchedule = DiscardedSchedule.create(selectedDate, originalSchedule);
 					discardedSchedulePersistencePort.save(discardedSchedule);
 				}
-				else if ( hasDetail && isPending && isBeforeStart ) {
+				else if ( hasDetail && isPending && isBeforeStart && !isExistsTodayNotPendingAfterEndTime) {
 					DiscardedSchedule discardedSchedule = DiscardedSchedule.create(selectedDate, originalSchedule);
 					discardedSchedulePersistencePort.save(discardedSchedule);
 
@@ -746,7 +749,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			if ( !isToday ) {
 				scheduleDetailPersistencePort.deleteByScheduleIdAndDate(originalSchedule.getId(), selectedDate);
 			}
-			else if ( isPending && isBeforeStart ) {
+			else if ( isPending && isBeforeStart && !isExistsTodayNotPendingAfterEndTime) {
 				scheduleDetailPersistencePort.deleteByScheduleIdAndDate(originalSchedule.getId(), selectedDate);
 
 				eventPort.publish(new ScheduleModifiedEvent(childId));

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -783,27 +783,43 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		LocalTime now = LocalTime.now();
 		List<LocalDate> requestDates = dates == null ? null : dateParser(dates);
 
+		// 반복일정일 때 dayOfWeek 필드가 비어있으면 예외
 		if (isRecurring && (dayOfWeek == null || dayOfWeek.isEmpty())) {
 			throw new KieroException(ScheduleErrorCode.DAY_OF_WEEK_NOT_NULLABLE_WHEN_IS_RECURRING_IS_TRUE);
 		}
+		// 단일일정일 때 dates 필드가 비어있으면 예외
 		if (!isRecurring && (dates == null || dates.isEmpty())) {
 			throw new KieroException(ScheduleErrorCode.DATE_NOT_NULLABLE_WHEN_IS_RECURRING_IS_FALSE);
 		}
+		// dayOfWeek 혹은 dates 필드가 모두 비어있으면 예외
 		if (dayOfWeek != null && dates != null) {
 			throw new KieroException(ScheduleErrorCode.DAY_OF_WEEK_XOR_DATE_REQUIRED);
 		}
+		// startTime이 endTime의 이전이 아니면 예외
 		if (!startTime.isBefore(endTime)) {
 			throw new KieroException(ScheduleErrorCode.INVALID_TIME_DURATION);
 		}
-		if (dates != null && requestDates.contains(today)) {
-			if (isFireLitToday) {
-				throw new KieroException(ScheduleErrorCode.SCHEDULE_NOT_MANIPULATED_WHEN_FIRE_LIT);
-			}
-			if (isExistsTodayNotPendingAfterEndTime) {
-				throw new KieroException(ScheduleErrorCode.SCHEDULE_NOT_MANIPULATED_WHEN_AFTER_SCHEDULE_NOT_PENDING);
-			}
-			if (!now.isBefore(startTime)) {
+		// 단일일정일 때
+		if (dates != null) {
+			// 요청 날짜 중 하나라도 오늘 이전이면 예외
+			if (requestDates.stream().anyMatch(date -> date.isBefore(today))) {
 				throw new KieroException(ScheduleErrorCode.SCHEDULE_IN_PAST);
+			}
+			// 일정 일자가 오늘을 포함하고 있을 때
+			if (requestDates.contains(today)) {
+				// 불피우기를 이미 완료하였다면 예외
+				if (isFireLitToday) {
+					throw new KieroException(ScheduleErrorCode.SCHEDULE_NOT_MANIPULATED_WHEN_FIRE_LIT);
+				}
+				// 이후 일정 중 아이가 행위를 진행한 일정이 있으면 예외
+				if (isExistsTodayNotPendingAfterEndTime) {
+					throw new KieroException(
+						ScheduleErrorCode.SCHEDULE_NOT_MANIPULATED_WHEN_AFTER_SCHEDULE_NOT_PENDING);
+				}
+				// 현재 시각이 일정의 startTime 이후라면 예외
+				if (!now.isBefore(startTime)) {
+					throw new KieroException(ScheduleErrorCode.SCHEDULE_IN_PAST);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -788,6 +789,15 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		}
 		if (!startTime.isBefore(endTime)) {
 			throw new KieroException(ScheduleErrorCode.INVALID_TIME_DURATION);
+		}
+		if (dates != null) {
+			LocalDate today = LocalDate.now();
+			LocalTime now = LocalTime.now();
+			List<LocalDate> requestDates = dateParser(dates);
+
+			if (requestDates.contains(today) && !now.isBefore(startTime)) {
+				throw new KieroException(ScheduleErrorCode.SCHEDULE_IN_PAST);
+			}
 		}
 	}
 

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
@@ -81,9 +81,7 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 		Long childId) {
 		checkIsExistsAndAccessibleByParentIdAndChildId(parentId, childId);
 
-		if (startDate.isAfter(endDate) || endDate.isBefore(startDate)) {
-			throw new KieroException(ScheduleErrorCode.INVALID_DATE_DURATION);
-		}
+		validateScheduleRange(startDate, endDate);
 
 		List<Schedule> schedules = schedulePersistencePort.findAllByChildId(childId);
 		if (schedules.isEmpty()) {
@@ -442,6 +440,33 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 
 		if (!parentChildAccessPort.existsByParentIdAndChildId(parentId, childId)) {
 			throw new KieroException(ScheduleErrorCode.NOT_ALLOWED_TO_CHILD);
+		}
+	}
+
+	private void validateScheduleRange(LocalDate startDate, LocalDate endDate) {
+		LocalDate today = LocalDate.now(clock);
+
+		// 종료일이 시작일보다 이후라면 예외
+		if (endDate.isBefore(startDate)) {
+			throw new KieroException(ScheduleErrorCode.INVALID_DATE_DURATION);
+		}
+
+		// startDate는 월요일이어야 함
+		if (startDate.getDayOfWeek() != java.time.DayOfWeek.MONDAY) {
+			throw new KieroException(ScheduleErrorCode.INVALID_WEEK_START_DATE);
+		}
+
+		// endDate는 일요일이어야 함
+		if (!endDate.equals(startDate.plusDays(6))) {
+			throw new KieroException(ScheduleErrorCode.INVALID_WEEK_END_DATE);
+		}
+
+		// 현재 기준 이전 12주 ~ 이후 12주 범위만 허용
+		LocalDate minAllowedStartDate = today.minusWeeks(13);
+		LocalDate maxAllowedEndDate = today.plusWeeks(13);
+
+		if (startDate.isBefore(minAllowedStartDate) || endDate.isAfter(maxAllowedEndDate)) {
+			throw new KieroException(ScheduleErrorCode.INVALID_SCHEDULE_RANGE);
 		}
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #199

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
클라이언트 뷰에서 원천적으로 막는다고 생각해 따로 예외처리 하지 않았던 조건들을 일괄 서버단에서도 적용하였습니다.
이 외 QA 시트에서 언급된 추가적인 상황을 반영하였습니다. 

토큰
- 기존 access token의 경우 유효하지 않을 때, http status만 반환하며 따로 response body는 보내지 않고 log.error로 예외상황을 출력하였음.
- response body를 반환하도록 수정하였음. 

일정
- 일정 탭 조회 시 조회 시작 일자는 월요일, 종료 일자는 일요일, 최대 12주 전후만 조회 가능하도록 조건을 추가하였음.
- 일정 추가/수정 시 request body의 필수 입력 데이터가 비어있을 시 예외를 던짐.
- 일정 등록/수정 시 일정 시작 시간과 종료 시간의 순서가 유효하지 않을 시 예외
- 당일 단일일정을 등록/수정할 경우 현재보다 이전 시간대의 일정을 등록하려 할 경우 예외
- 단일일정을 과거 일자로 수정하려 할 시 예외
- 오늘 일정 수정 시 일정 상태가 pending이 아니거나, 이미 시작 시간이 지난 일정을 수정하려 할 경우 예외
- 오늘 일정을 삭제 시, 삭제하려는 일정 이후 일정 중 아이가 행위를 수행한 일정이 있다면 예외

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증 실패 시 JSON 구조화된 오류 응답 도입(헤더 기반 오류 종류 판단 포함)

* **개선 사항**
  * 인증 관련 오류 메시지와 용어를 JWT 중심으로 일관화
  * 스케줄 이름 검증 강화(@NotEmpty 추가)

* **버그 픽스 / 검증 강화**
  * 스케줄 조회: 주(월요일~일요일) 및 ±12주 범위 검증 추가
  * 스케줄 생성/수정/삭제: 시간 순서, 과거 일정, 특정 상태(예: 당일 불 피우기 완료 등)에 따른 조작 제한 등 세부 검증 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->