### PR TITLE
[fix] #206 - 오늘의 현황에서 일정이 중복으로 노출되는 문제 해결

### DIFF
--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -457,7 +457,6 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			6) 오늘 일정들의 불조각 종류를 재계산합니다.
 			 */
 			case RecurringToRecurring -> {
-				scheduleDetailPersistencePort.deleteByScheduleIdAndDate(originalSchedule.getId(), selectedDate);
 
 				List<DayOfWeek> originalDayOfWeeks = scheduleRepeatDaysPersistencePort.findDayOfWeeksByScheduleId(
 					originalSchedule.getId());

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -493,9 +493,10 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				DayOfWeek todayDayOfWeek = DayOfWeek.from(today.getDayOfWeek());
 
 				// 추가된 일정의 요일에 오늘이 포함되고 일정 시작 시간이 현재 이후며, 아이가 오늘 불피우기를 하지 않았고 아이가 미리 수행한 일정이 없다면
-				// 1) 추가된 일정의 scheduleDetail 생성
-				// 2) 오늘 일정들의 stoneType 재계산
-				// 3) 이벤트를 발행하도록 설정
+				// 1) 오리지널 일정의 오늘자 scheduleDetail 삭제
+				// 2) 추가된 일정의 scheduleDetail 생성
+				// 3) 오늘 일정들의 stoneType 재계산
+				// 4) 이벤트를 발행하도록 설정
 				if (requestDayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 					scheduleDetailPersistencePort.deleteByScheduleIdAndDate(originalSchedule.getId(), today);
 

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -447,12 +447,12 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			/*
 			반복일정 -> 반복일정이고 요일 변화가 있을 때,
 			1) selectedDate를 기준으로 기존의 scheduleDetail가 존재한다면 삭제합니다.
-			2) 기존의 일정의 반복종료일자를 selectedDate 하루 전으로 업데이트합니다.
+			2) 기존의 일정의 반복종료일자를 selectedDate 이전 마지막 반복일자로 업데이트합니다.
 			3) request body로 새로운 schedule을 생성하고, 반복시작일자는 selectedDate로 합니다.
 			4) request body와 새로 생성한 schedule로 scheduleRepeatDays를 생성합니다.
 
 			새로 생성된 일정의 날짜가 오늘이고 일정 시작 시각이 현재보다 이후라면,
-			4) scheduleDetail을 추가로 생성합니다.
+			4) scheduleDetail을 추가로 6생성합니다.
 			5) 이벤트 발행을 위해 isEffectsToChildSchedule을 true로 바꿉니다.
 			6) 오늘 일정들의 불조각 종류를 재계산합니다.
 			 */
@@ -498,6 +498,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				// 2) 오늘 일정들의 stoneType 재계산
 				// 3) 이벤트를 발행하도록 설정
 				if (requestDayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
+					scheduleDetailPersistencePort.deleteByScheduleIdAndDate(originalSchedule.getId(), today);
 
 					ScheduleDetail scheduleDetail = ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, saved);
 					scheduleDetailPersistencePort.save(scheduleDetail);


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #206

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기존에는 진입날짜를 기준으로 존재하는 scheduleDetail이 있다면 오리지널 일정의 scheduleDetail을 삭제하였습니다. 
반복일정의 'scheduleDetail'이 존재한다는 것은, 과거의 일정이거나 오늘이 '반복 요일'에 해당함을 뜻합니다. (반복 일정의 경우 매일 00시에 scheduleDetail이 생성되므로). 이 중, 과거의 일정일 경우 아예 수정이 불가능하므로, 어떠한 반복 일정이 '수정 가능한 scheduleDetail'을 가진다는 말은 scheduleDetail의 date가 확정적으로 오늘임을 뜻합니다. 

따라서 기존의 selectedDate 기반으로 scheduleDetail이 삭제되었던 로직을 삭제하고,수정 후 일정에 오늘 요일이 포함되어 있으면 오늘자 scheduleDetail을 삭제하는 로직을 추가하였습니다. 

주석을 변경하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **Bug Fixes**
  * 반복 스케줄 변경 시 종료 날짜 계산 로직 개선으로 정확성 향상
  * 특정 조건에서의 스케줄 상세 정보 처리 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->