### PR TITLE
[refactor] #208 - 더 이상 사용되지 않는 Schedule 삭제 로직 추가, dailyJob 스케쥴러 시행 보장, repeatStartDate 계산 로직 핫픽스

### DIFF
--- a/src/main/java/com/kiero/schedule/adapter/in/scheduler/DailyScheduleJob.java
+++ b/src/main/java/com/kiero/schedule/adapter/in/scheduler/DailyScheduleJob.java
@@ -25,6 +25,7 @@ public class DailyScheduleJob {
 		LocalDate today = LocalDate.now(clock);
 
 		scheduleSchedulerUseCase.createTodayScheduleDetail();
+		scheduleSchedulerUseCase.deleteObsoleteNonRecurringSchedules();
 		sseBroadcastUseCase.broadcastDateChangedSafely(today);
 	}
 }

--- a/src/main/java/com/kiero/schedule/adapter/in/scheduler/DailyScheduleJob.java
+++ b/src/main/java/com/kiero/schedule/adapter/in/scheduler/DailyScheduleJob.java
@@ -1,8 +1,12 @@
 package com.kiero.schedule.adapter.in.scheduler;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDate;
 
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -10,16 +14,31 @@ import com.kiero.global.sse.application.port.in.SseBroadcastUseCase;
 import com.kiero.schedule.application.port.in.ScheduleSchedulerUseCase;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DailyScheduleJob {
 
-	private final Clock clock;
+	private static final String DAILY_JOB_KEY_PREFIX = "daily-job:executed:";
+	private static final Duration DAILY_JOB_KEY_TTL = Duration.ofHours(48);
 
+	private final Clock clock;
+	private final StringRedisTemplate stringRedisTemplate;
 	private final ScheduleSchedulerUseCase scheduleSchedulerUseCase;
 	private final SseBroadcastUseCase sseBroadcastUseCase;
 
+	@EventListener(ApplicationReadyEvent.class)
+	public void recoverIfMissed() {
+		LocalDate today = LocalDate.now(clock);
+		String key = DAILY_JOB_KEY_PREFIX + today;
+
+		if (!Boolean.TRUE.equals(stringRedisTemplate.hasKey(key))) {
+			log.warn("오늘({}) DailySchedule job 미실행 감지 - 보정 실행", today);
+			runDailyJob();
+		}
+	}
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void runDailyJob() {
 		LocalDate today = LocalDate.now(clock);
@@ -27,5 +46,9 @@ public class DailyScheduleJob {
 		scheduleSchedulerUseCase.createTodayScheduleDetail();
 		scheduleSchedulerUseCase.deleteObsoleteNonRecurringSchedules();
 		sseBroadcastUseCase.broadcastDateChangedSafely(today);
+
+		String key = DAILY_JOB_KEY_PREFIX + today;
+		stringRedisTemplate.opsForValue().set(key, "1", DAILY_JOB_KEY_TTL);
+		log.info("오늘({}) DailySchedule job 완료 - Redis 플래그 저장", today);
 	}
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/DiscardedSchedulePersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/DiscardedSchedulePersistenceAdapter.java
@@ -47,4 +47,9 @@ public class DiscardedSchedulePersistenceAdapter implements DiscardedSchedulePer
 	public List<DiscardedSchedule> findAllByDate(LocalDate today) {
 		return discardedScheduleRepository.findAllByDate(today);
 	}
+
+	@Override
+	public void deleteByScheduleId(Long id) {
+		discardedScheduleRepository.deleteByScheduleId(id);
+	}
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/DiscardedScheduleRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/DiscardedScheduleRepository.java
@@ -50,4 +50,5 @@ public interface DiscardedScheduleRepository extends JpaRepository<DiscardedSche
 
 	List<DiscardedSchedule> findAllByDate(LocalDate today);
 
+	void deleteByScheduleId(Long id);
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
@@ -110,4 +110,9 @@ public class ScheduleDetailPersistenceAdapter implements ScheduleDetailPersisten
 		return scheduleDetailRepository.findByIdWithSchedule(scheduleDetailId);
 	}
 
+	@Override
+	public void deleteAllByScheduleId(Long scheduleId) {
+		scheduleDetailRepository.deleteAllByScheduleId(scheduleId);
+	}
+
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
@@ -156,4 +156,6 @@ public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, 
 		where sd.id = :scheduleDetailId
 		""")
 	Optional<ScheduleDetail> findByIdWithSchedule(Long scheduleDetailId);
+
+	void deleteAllByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/SchedulePersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/SchedulePersistenceAdapter.java
@@ -46,4 +46,9 @@ public class SchedulePersistenceAdapter implements SchedulePersistencePort {
 		scheduleRepository.deleteById(scheduleId);
 	}
 
+	@Override
+	public void deleteObsoleteNonRecurringSchedules() {
+		scheduleRepository.deleteObsoleteNonRecurringSchedules();
+	}
+
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/SchedulePersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/SchedulePersistenceAdapter.java
@@ -41,4 +41,9 @@ public class SchedulePersistenceAdapter implements SchedulePersistencePort {
 		return scheduleRepository.findById(scheduleId);
 	}
 
+	@Override
+	public void deleteById(Long scheduleId) {
+		scheduleRepository.deleteById(scheduleId);
+	}
+
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.kiero.schedule.domain.Schedule;
@@ -14,4 +16,13 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
 	Optional<Schedule> findFirstByChildIdOrderByCreatedAtDesc(Long childId);
 
+	@Modifying
+	@Query("""                                                                               
+      DELETE FROM Schedule s
+      WHERE s.isRecurring = false
+      AND NOT EXISTS (
+          SELECT 1 FROM ScheduleDetail sd WHERE sd.schedule = s
+      )
+  """)
+	void deleteObsoleteNonRecurringSchedules();
 }

--- a/src/main/java/com/kiero/schedule/application/port/in/ScheduleSchedulerUseCase.java
+++ b/src/main/java/com/kiero/schedule/application/port/in/ScheduleSchedulerUseCase.java
@@ -9,4 +9,5 @@ public interface ScheduleSchedulerUseCase {
 
 	void bulkMarkAndPushEventIfUpdateExists(LocalDate today, LocalTime now);
 
+	void deleteObsoleteNonRecurringSchedules();
 }

--- a/src/main/java/com/kiero/schedule/application/port/out/DiscardedSchedulePersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/DiscardedSchedulePersistencePort.java
@@ -22,4 +22,6 @@ public interface DiscardedSchedulePersistencePort {
 	);
 
 	List<DiscardedSchedule> findAllByDate(LocalDate today);
+
+	void deleteByScheduleId(Long id);
 }

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
@@ -46,4 +46,6 @@ public interface ScheduleDetailPersistencePort {
 	boolean existsByDateAndChildIdAfterEndTime(LocalDate date, Long childId, LocalTime endTime);
 
 	Optional<ScheduleDetail> findByIdWithSchedule(Long scheduleDetailId);
+
+	void deleteAllByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/kiero/schedule/application/port/out/SchedulePersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/SchedulePersistencePort.java
@@ -18,4 +18,6 @@ public interface SchedulePersistencePort {
 	Optional<Schedule> findById(Long scheduleId);
 
 	void deleteById(Long scheduleId);
+
+	void deleteObsoleteNonRecurringSchedules();
 }

--- a/src/main/java/com/kiero/schedule/application/port/out/SchedulePersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/SchedulePersistencePort.java
@@ -17,4 +17,5 @@ public interface SchedulePersistencePort {
 
 	Optional<Schedule> findById(Long scheduleId);
 
+	void deleteById(Long scheduleId);
 }

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -1058,5 +1058,6 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		scheduleDetailPersistencePort.deleteAllByScheduleId(originalSchedule.getId());
 		scheduleRepeatDaysPersistencePort.deleteAllByScheduleId(originalSchedule.getId());
 		schedulePersistencePort.deleteById(originalSchedule.getId());
+		discardedSchedulePersistencePort.deleteByScheduleId(originalSchedule.getId());
 	}
 }

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -540,6 +540,10 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				LocalDate originalScheduleRepeatEndDate = repeatEndDateResolver(selectedDate, dayOfWeeks);
 
+				// 원본 일정의 오늘자 scheduleDetail이 존재하는가 (= 오늘이 원본일정의 반복요일에 해당했는가)
+				boolean isOriginalDetailExists = scheduleDetailPersistencePort.findByScheduleIdAndDate(
+					originalSchedule.getId(), selectedDate).isPresent();
+
 				// 더 이상 유효하지 않은 반복 일정은 하드딜리트
 				if (originalScheduleRepeatEndDate.isBefore(originalSchedule.getRepeatStartDate())) {
 					deleteScheduleSet(originalSchedule);
@@ -566,11 +570,10 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				scheduleRepeatDaysPersistencePort.saveAll(scheduleRepeatDays);
 
-				Optional<ScheduleDetail> originalDetail = scheduleDetailPersistencePort.findByScheduleIdAndDate(
-					originalSchedule.getId(), selectedDate);
-
-				if(originalDetail.isPresent()) {
-					originalDetail.get().changeSchedule(saved);
+				if(isOriginalDetailExists) {
+					ScheduleDetail scheduleDetail = ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING,
+						null, saved);
+					scheduleDetailPersistencePort.save(scheduleDetail);
 					if (request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 						recalculateTodayStoneTypes(childId);
 						isEffectsToChildSchedule = true;
@@ -1013,8 +1016,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		if (selectedDate.isAfter(today)) { // 진입 일자가 미래 일자면
 
 			if (isAdd) baseDate = selectedDate; // 일정 추가의 상황이라면
-			else if (!includesToday) baseDate = selectedDate; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되지 않는다면
-			else if (startTime.isAfter(now)) baseDate = today; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이후라면
+			else if (includesToday && startTime.isAfter(now)) baseDate = today; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이후라면
 			else baseDate = selectedDate; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이전이라면
 
 		} else if (selectedDate.isBefore(today)) {

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -106,7 +106,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		if (request.isRecurring()) {
 
 			List<DayOfWeek> dayOfWeeks = dayOfWeekParser(request.dayOfWeek());
-			LocalDate repeatStartDate = repeatStartDateResolver(request.firstOrderDate(), dayOfWeeks, request.startTime(), today, now);
+			LocalDate repeatStartDate = repeatStartDateResolver(true, request.firstOrderDate(), dayOfWeeks, request.startTime(), today, now);
 
 			throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(), request.endTime(), child.getId(), null, repeatStartDate, null);
 
@@ -134,7 +134,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			// 3) 이벤트를 발행하도록 설정
 			DayOfWeek todayDayOfWeek = DayOfWeek.from(today.getDayOfWeek());
 
-			if (dayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
+			if (repeatStartDate.isEqual(today) && dayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 
 				ScheduleDetail scheduleDetail = ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, saved);
 				scheduleDetailPersistencePort.save(scheduleDetail);
@@ -403,7 +403,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				List<DayOfWeek> dayOfWeeks = dayOfWeekParser(request.dayOfWeek());
 
-				LocalDate repeatStartDate = repeatStartDateResolver(selectedDate, dayOfWeeks, request.startTime(), today, now);
+				LocalDate repeatStartDate = repeatStartDateResolver(false, selectedDate, dayOfWeeks, request.startTime(), today, now);
 
 				throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(),
 					request.endTime(), childId, selectedDate, repeatStartDate, originalSchedule.getId());
@@ -434,7 +434,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				// 1) 추가된 일정의 scheduleDetail 생성
 				// 2) 오늘 일정들의 stoneType 재계산
 				// 3) 이벤트를 발행하도록 설정
-				if (dayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
+				if (repeatStartDate.isEqual(today) && dayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 
 					ScheduleDetail scheduleDetail = ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, saved);
 					scheduleDetailPersistencePort.save(scheduleDetail);
@@ -462,7 +462,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 					originalSchedule.getId());
 				List<DayOfWeek> requestDayOfWeeks = dayOfWeekParser(request.dayOfWeek());
 
-				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(selectedDate, requestDayOfWeeks, request.startTime(), today, now);
+				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(false, selectedDate, requestDayOfWeeks, request.startTime(), today, now);
 
 				throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(),
 					request.endTime(), childId, selectedDate, newScheduleRepeatStartDate, originalSchedule.getId());
@@ -472,10 +472,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				// 더 이상 유효하지 않은 반복 일정은 하드딜리트
 				if (originalScheduleRepeatEndDate.isBefore(originalSchedule.getRepeatStartDate())) {
 					deleteScheduleSet(originalSchedule);
-					return;
 				}
-
-				originalSchedule.changeRepeatEndDate(originalScheduleRepeatEndDate);
+				else originalSchedule.changeRepeatEndDate(originalScheduleRepeatEndDate);
 
 				Schedule newSchedule = Schedule.create(
 					originalSchedule.getParent(),
@@ -504,7 +502,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				// 2) 추가된 일정의 scheduleDetail 생성
 				// 3) 오늘 일정들의 stoneType 재계산
 				// 4) 이벤트를 발행하도록 설정
-				if (requestDayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
+				if (newScheduleRepeatStartDate.isEqual(today) && requestDayOfWeeks.contains(todayDayOfWeek) && request.startTime().isAfter(now) && !isFireLitToday && !isExistsTodayNotPendingAfterEndTime) {
 					scheduleDetailPersistencePort.deleteByScheduleIdAndDate(originalSchedule.getId(), today);
 
 					ScheduleDetail scheduleDetail = ScheduleDetail.create(today, null, null, ScheduleStatus.PENDING, null, saved);
@@ -535,7 +533,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				boolean sameDays = new HashSet<>(dayOfWeekParser(request.dayOfWeek())).equals(new HashSet<>(dayOfWeeks));
 				if (!sameDays) throw new KieroException(ScheduleErrorCode.DAY_OF_WEEK_CANNOT_BE_MODIFIED);
 
-				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(selectedDate, dayOfWeeks, request.startTime(), today, now);
+				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(false, selectedDate, dayOfWeeks, request.startTime(), today, now);
 
 				throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(),
 					request.endTime(), childId, selectedDate, newScheduleRepeatStartDate, originalSchedule.getId());
@@ -545,10 +543,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				// 더 이상 유효하지 않은 반복 일정은 하드딜리트
 				if (originalScheduleRepeatEndDate.isBefore(originalSchedule.getRepeatStartDate())) {
 					deleteScheduleSet(originalSchedule);
-					return;
 				}
-
-				originalSchedule.changeRepeatEndDate(originalScheduleRepeatEndDate);
+				else originalSchedule.changeRepeatEndDate(originalScheduleRepeatEndDate);
 
 				Schedule newSchedule = Schedule.create(
 					originalSchedule.getParent(),
@@ -725,7 +721,6 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				// 더 이상 유효하지 않은 반복 일정은 하드딜리트
 				if (repeatEndDate.isBefore(originalSchedule.getRepeatStartDate())) {
 					deleteScheduleSet(originalSchedule);
-					return;
 				}
 
 				// 1) 유효한 일정은 repeatEndDate 업데이트
@@ -1002,6 +997,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 	// 반복일정이 첫 번째로 시작되는 일자를 구하는 리졸버
 	private LocalDate repeatStartDateResolver(
+		boolean isAdd,
 		LocalDate selectedDate,
 		List<DayOfWeek> repeatDays,
 		LocalTime startTime,
@@ -1011,18 +1007,21 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 		LocalDate baseDate;
 
-		// 수정 후 반복 요일에 오늘이 포함되는지 여부
+		// 요청의 반복 요일에 오늘이 포함되는지 여부
 		boolean includesToday = repeatDays.contains(DayOfWeek.from(today.getDayOfWeek()));
 
 		if (selectedDate.isAfter(today)) { // 진입 일자가 미래 일자면
 
-			if (!includesToday) baseDate = selectedDate; // 반복요일에 오늘이 포함되지 않는다면
-			else if (startTime.isAfter(now)) baseDate = today; // 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이후라면
-			else baseDate = selectedDate; // 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이전이라면
+			if (isAdd) baseDate = selectedDate; // 일정 추가의 상황이라면
+			else if (!includesToday) baseDate = selectedDate; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되지 않는다면
+			else if (startTime.isAfter(now)) baseDate = today; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이후라면
+			else baseDate = selectedDate; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이전이라면
 
 		} else if (selectedDate.isBefore(today)) {
 
-			baseDate = today; // 진입 일자가 과거 일자면 baseDate는 오늘
+			// 반복 요일에 오늘이 포함되고, 일정 시작 시간이 현재보다 이후라면 baseDate는 오늘, 아니면 내일
+			if (includesToday && startTime.isAfter(now)) baseDate = today;
+			else baseDate = today.plusDays(1);
 
 		} else { // 진입 일자가 오늘이면
 			// 반복 요일에 오늘이 포함되고, 일자의 시작 시간이 현재 시간 이후라면 baseDate는 오늘

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -463,10 +463,17 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				List<DayOfWeek> requestDayOfWeeks = dayOfWeekParser(request.dayOfWeek());
 
 				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(selectedDate, requestDayOfWeeks, request.startTime(), today, now);
-				LocalDate originalScheduleRepeatEndDate = repeatEndDateResolver(selectedDate, originalDayOfWeeks);
 
 				throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(),
 					request.endTime(), childId, selectedDate, newScheduleRepeatStartDate, originalSchedule.getId());
+
+				LocalDate originalScheduleRepeatEndDate = repeatEndDateResolver(selectedDate, originalDayOfWeeks);
+
+				// 더 이상 유효하지 않은 반복 일정은 하드딜리트
+				if (originalScheduleRepeatEndDate.isBefore(originalSchedule.getRepeatStartDate())) {
+					deleteScheduleSet(originalSchedule);
+					return;
+				}
 
 				originalSchedule.changeRepeatEndDate(originalScheduleRepeatEndDate);
 
@@ -529,10 +536,17 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				if (!sameDays) throw new KieroException(ScheduleErrorCode.DAY_OF_WEEK_CANNOT_BE_MODIFIED);
 
 				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(selectedDate, dayOfWeeks, request.startTime(), today, now);
-				LocalDate originalScheduleRepeatEndDate = repeatEndDateResolver(selectedDate, dayOfWeeks);
 
 				throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(),
 					request.endTime(), childId, selectedDate, newScheduleRepeatStartDate, originalSchedule.getId());
+
+				LocalDate originalScheduleRepeatEndDate = repeatEndDateResolver(selectedDate, dayOfWeeks);
+
+				// 더 이상 유효하지 않은 반복 일정은 하드딜리트
+				if (originalScheduleRepeatEndDate.isBefore(originalSchedule.getRepeatStartDate())) {
+					deleteScheduleSet(originalSchedule);
+					return;
+				}
 
 				originalSchedule.changeRepeatEndDate(originalScheduleRepeatEndDate);
 
@@ -708,6 +722,17 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 					originalSchedule.getId());
 				LocalDate repeatEndDate = repeatEndDateResolver(selectedDate, dayOfWeeks);
 
+				// 더 이상 유효하지 않은 반복 일정은 하드딜리트
+				if (repeatEndDate.isBefore(originalSchedule.getRepeatStartDate())) {
+					deleteScheduleSet(originalSchedule);
+					return;
+				}
+
+				// 1) 유효한 일정은 repeatEndDate 업데이트
+				// 삭제 요청한 일정이 오늘이고 유효하다면
+				// 2) scheduleDetail 삭제
+				// 3) 이벤트 발행
+				// 4) 불조각 종류 재계산
 				if ( !isToday ) {
 					originalSchedule.changeRepeatEndDate(repeatEndDate);
 				}
@@ -1028,5 +1053,11 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			cursor = cursor.minusDays(1);
 		}
 		return selectedDate.minusDays(1);
+	}
+
+	private void deleteScheduleSet(Schedule originalSchedule) {
+		scheduleDetailPersistencePort.deleteAllByScheduleId(originalSchedule.getId());
+		scheduleRepeatDaysPersistencePort.deleteAllByScheduleId(originalSchedule.getId());
+		schedulePersistencePort.deleteById(originalSchedule.getId());
 	}
 }

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleSchedulerService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleSchedulerService.java
@@ -11,14 +11,13 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.kiero.child.application.port.out.ChildLoadPort;
-import com.kiero.parent.application.port.out.ParentLoadPort;
 import com.kiero.schedule.application.dto.ScheduleStatusUpdatedEvent;
 import com.kiero.schedule.application.dto.ScheduleUpdateEventTarget;
 import com.kiero.schedule.application.port.in.ScheduleSchedulerUseCase;
 import com.kiero.schedule.application.port.out.DiscardedSchedulePersistencePort;
 import com.kiero.schedule.application.port.out.ScheduleDetailPersistencePort;
 import com.kiero.schedule.application.port.out.ScheduleEventPort;
+import com.kiero.schedule.application.port.out.SchedulePersistencePort;
 import com.kiero.schedule.application.port.out.ScheduleRepeatDaysPersistencePort;
 import com.kiero.schedule.domain.Schedule;
 import com.kiero.schedule.domain.ScheduleDetail;
@@ -41,8 +40,7 @@ public class ScheduleSchedulerService implements ScheduleSchedulerUseCase {
 	private final ScheduleEventPort scheduleEventPort;
 
 	private final ScheduleCommandService scheduleCommandService;
-	private final ParentLoadPort parentLoadPort;
-	private final ChildLoadPort childLoadPort;
+	private final SchedulePersistencePort schedulePersistencePort;
 
 	@Override
 	@Transactional
@@ -88,4 +86,11 @@ public class ScheduleSchedulerService implements ScheduleSchedulerUseCase {
 			}
 		}
 	}
+
+	@Override
+	@Transactional
+	public void deleteObsoleteNonRecurringSchedules() {
+		schedulePersistencePort.deleteObsoleteNonRecurringSchedules();
+	}
+
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #208
- closes #212

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 반복일정 수정/삭제 요청이 들어왔을 때, 오리지널 반복일정이 더 이상 사용되지 않는다면 하드딜리트되도록 로직을 추가하였습니다. 
- 매일 00시에 작동하는 스케쥴러에, 단일일정 중 ScheduleDetail이 없는 Schedule은 하드딜리트되도록 로직을 추가하였습니다. 
-- 원래 더 이상 사용되지 않는 단일일정도 단일일정 수정/삭제 요청이 들어올 때마다 시행되도록 하였으나, 해당하지 않는 상황에서도 요청마다 불필요한 추가적인 쿼리가 발생할 것 같아 스케쥴러 내부에 포함시키도록 하였습니다. (반복일정 수정/삭제는 추가적인 쿼리가 발생하지 않아 각 메서드 내부에 포함하였습니다.)
-  애플리케이션 시작 시 Redis에서 오늘 날짜 key를 조회하여 runDailyJob이 미실행 상태라면 수동으로 호출합니다. 실행 완료 후에는 해당 날짜를 key로 Redis에 등록합니다.
- 일정 등록 시 repeatStartDate가 제대로 계산되지 않던 문제를 해결하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
스케쥴러 스케쥴링 시간을 조작하여 scheduleDetail이 없는 단일 Schedule이 삭제되는 것 정상작동 확인하였습니다.
기간이 유효하지 않은 반복 Schedule이 삭제되는 것 확인하였습니다.

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
로직이 복잡해서 코드 상 왜 repeatEndDate < repeatStartDate가 되는 상황이 존재하는지, 
왜 scheduleDetail이 존재하지 않는 Schedule이 존재하는지 등등이 직관적으로 이해되지 않으실 수도 있을 것 같습니다!!
편하게 물어보셔도 댑니다..!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 앱 시작 시 누락된 일일 작업을 감지해 자동으로 복구 실행하고 실행 상태를 기록합니다.
* **버그 수정**
  * 반복 스케줄의 해석 결과 종료일이 시작일보다 이전일 때 관련 항목을 완전 삭제해 불일치 문제 해결.
* **개선 사항**
  * 일일 작업 실행 후 오래된 비반복 스케줄을 자동 정리하도록 워크플로 개선.
  * 반복 스케줄 생성·업데이트·삭제 시 관련 상세 항목과 연관 데이터 정리 일관성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->