### PR TITLE
[refactor] #213 - 아이가 일정을 인증하지 않고 스킵한 일정도 포함하여 반환

### DIFF
--- a/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
@@ -365,9 +365,7 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 
 		boolean isFireLitToday =  filteredScheduleDetails.stream().anyMatch(sd -> sd.getStoneUsedAt() != null);
 
-		// 아이가 인증하지 않고 스킵한 일정을 제외하여 dto building
 		List<ScheduleProgressForParentDto.ScheduleDto> schedules = filteredScheduleDetails.stream()
-			.filter(sd -> sd.getScheduleStatus() != ScheduleStatus.SKIPPED)
 			.map(sd -> {
 				boolean isOngoing = !now.isBefore(sd.getSchedule().getStartTime()) && now.isBefore(sd.getSchedule().getEndTime());
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #213

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기획 의도에 따라, 부모의 오늘의 현황 조회 api에서 스킵된 일정도 response에 포함하도록 수정하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 부모의 일정 진행 현황 조회 시 건너뛴 일정이 결과에 포함되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->