### PR TITLE
[refactor] #216 - repeatStartDate가 제대로 계산되지 않았던 문제 해결

### DIFF
--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -106,7 +106,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		if (request.isRecurring()) {
 
 			List<DayOfWeek> dayOfWeeks = dayOfWeekParser(request.dayOfWeek());
-			LocalDate repeatStartDate = repeatStartDateResolver(true, request.firstOrderDate(), dayOfWeeks, request.startTime(), today, now);
+			LocalDate repeatStartDate = repeatStartDateResolver(request.firstOrderDate(), dayOfWeeks, request.startTime(), today, now);
 
 			throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(), request.endTime(), child.getId(), null, repeatStartDate, null);
 
@@ -403,7 +403,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 				List<DayOfWeek> dayOfWeeks = dayOfWeekParser(request.dayOfWeek());
 
-				LocalDate repeatStartDate = repeatStartDateResolver(false, selectedDate, dayOfWeeks, request.startTime(), today, now);
+				LocalDate repeatStartDate = repeatStartDateResolver(selectedDate, dayOfWeeks, request.startTime(), today, now);
 
 				throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(),
 					request.endTime(), childId, selectedDate, repeatStartDate, originalSchedule.getId());
@@ -462,7 +462,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 					originalSchedule.getId());
 				List<DayOfWeek> requestDayOfWeeks = dayOfWeekParser(request.dayOfWeek());
 
-				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(false, selectedDate, requestDayOfWeeks, request.startTime(), today, now);
+				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(selectedDate, requestDayOfWeeks, request.startTime(), today, now);
 
 				throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(),
 					request.endTime(), childId, selectedDate, newScheduleRepeatStartDate, originalSchedule.getId());
@@ -533,7 +533,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 				boolean sameDays = new HashSet<>(dayOfWeekParser(request.dayOfWeek())).equals(new HashSet<>(dayOfWeeks));
 				if (!sameDays) throw new KieroException(ScheduleErrorCode.DAY_OF_WEEK_CANNOT_BE_MODIFIED);
 
-				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(false, selectedDate, dayOfWeeks, request.startTime(), today, now);
+				LocalDate newScheduleRepeatStartDate = repeatStartDateResolver(selectedDate, dayOfWeeks, request.startTime(), today, now);
 
 				throwExceptionWhenAddRecurringScheduleIfDuplicated(request.dayOfWeek(), request.startTime(),
 					request.endTime(), childId, selectedDate, newScheduleRepeatStartDate, originalSchedule.getId());
@@ -1000,7 +1000,6 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 	// 반복일정이 첫 번째로 시작되는 일자를 구하는 리졸버
 	private LocalDate repeatStartDateResolver(
-		boolean isAdd,
 		LocalDate selectedDate,
 		List<DayOfWeek> repeatDays,
 		LocalTime startTime,
@@ -1015,9 +1014,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 		if (selectedDate.isAfter(today)) { // 진입 일자가 미래 일자면
 
-			if (isAdd) baseDate = selectedDate; // 일정 추가의 상황이라면
-			else if (includesToday && startTime.isAfter(now)) baseDate = today; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이후라면
-			else baseDate = selectedDate; // 일정 수정의 상황이고, 반복요일에 오늘이 포함되고, 일정 시작시간이 현재보다 이전이라면
+			baseDate = selectedDate;
 
 		} else if (selectedDate.isBefore(today)) {
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #216

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
반복일정의 반복시작일자가 잘못 계산되어 동일한 시간대에 두 개의 일정이 노출되었던 문제를 해결하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
미처 발견하지 못했던 자잘한 이슈들이 꽤 있네요.. 논리 로직이 복잡하다 보니 놓친 부분들이 있는 것 같습니다. ㅠ 
앱으로 계속 테스트하면서 보완해 나가야될 듯 합니다. ㅠ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 반복 일정의 시작 날짜 계산 로직을 최적화하여 더욱 안정적인 일정 생성을 지원합니다.
  * 일정 중복 및 충돌 감지 기능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->