### PR TITLE
[feat] #215 -시간이 지나 일정이 '현재 진행'으로 바뀌었을 때 이벤트 발행

### DIFF
--- a/src/main/java/com/kiero/schedule/adapter/in/scheduler/ScheduleStatusJob.java
+++ b/src/main/java/com/kiero/schedule/adapter/in/scheduler/ScheduleStatusJob.java
@@ -27,6 +27,7 @@ public class ScheduleStatusJob {
 		LocalTime now = LocalTime.now(clock);
 
 		scheduleSchedulerUseCase.bulkMarkAndPushEventIfUpdateExists(today, now);
+		scheduleSchedulerUseCase.pushEventIfScheduleStart(today, now);
 
 	}
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
-import com.kiero.schedule.application.dto.ScheduleUpdateEventTarget;
+import com.kiero.schedule.application.dto.ScheduleEventTarget;
 import com.kiero.schedule.application.port.out.ScheduleDetailPersistencePort;
 import com.kiero.schedule.domain.ScheduleDetail;
 
@@ -86,7 +86,7 @@ public class ScheduleDetailPersistenceAdapter implements ScheduleDetailPersisten
 	}
 
 	@Override
-	public List<ScheduleUpdateEventTarget> findScheduleUpdateEventTarget(LocalDate today, LocalTime now) {
+	public List<ScheduleEventTarget> findScheduleUpdateEventTarget(LocalDate today, LocalTime now) {
 		return scheduleDetailRepository.findScheduleUpdateEventTargets(today, now);
 	}
 

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailPersistenceAdapter.java
@@ -91,6 +91,13 @@ public class ScheduleDetailPersistenceAdapter implements ScheduleDetailPersisten
 	}
 
 	@Override
+	public List<ScheduleEventTarget> findScheduleStartEventTarget(LocalDate today, LocalTime now) {
+		LocalTime nowStart = now.withSecond(0).withNano(0);
+		LocalTime nowEnd = nowStart.plusMinutes(1);
+		return scheduleDetailRepository.findScheduleStartEventTargets(today, nowStart, nowEnd);
+	}
+
+	@Override
 	public void bulkMarkPendingAsFailed(LocalDate today, LocalTime now) {
 		scheduleDetailRepository.bulkMarkPendingAsFailed(today, now);
 	}

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import com.kiero.schedule.application.dto.ScheduleUpdateEventTarget;
+import com.kiero.schedule.application.dto.ScheduleEventTarget;
 import com.kiero.schedule.domain.ScheduleDetail;
 
 @Repository
@@ -81,7 +81,7 @@ public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, 
 	);
 
 	@Query("""
-		select distinct new com.kiero.schedule.application.dto.ScheduleUpdateEventTarget(
+		select distinct new com.kiero.schedule.application.dto.ScheduleEventTarget(
 			c.id,
 			p.id
 		)
@@ -97,7 +97,7 @@ public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, 
 		  )
 		  and s.endTime <= :now
 """)
-	List<ScheduleUpdateEventTarget> findScheduleUpdateEventTargets(
+	List<ScheduleEventTarget> findScheduleUpdateEventTargets(
 		@Param("today") LocalDate today,
 		@Param("now") LocalTime now
 	);

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
@@ -157,5 +157,26 @@ public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, 
 		""")
 	Optional<ScheduleDetail> findByIdWithSchedule(Long scheduleDetailId);
 
+	@Query("""
+		select distinct new com.kiero.schedule.application.dto.ScheduleEventTarget(
+			c.id,
+			p.id
+		)
+		from ScheduleDetail sd
+		join sd.schedule s
+		join s.child c
+		join ParentChild pc on pc.child.id = c.id
+		join pc.parent p
+		where sd.date = :today
+		  and sd.scheduleStatus = com.kiero.schedule.domain.enums.ScheduleStatus.PENDING
+		  and s.startTime >= :nowStart
+		  and s.startTime < :nowEnd
+""")
+	List<ScheduleEventTarget> findScheduleStartEventTargets(
+		@Param("today") LocalDate today,
+		@Param("nowStart") LocalTime nowStart,
+		@Param("nowEnd") LocalTime nowEnd
+	);
+
 	void deleteAllByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleEventTarget.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleEventTarget.java
@@ -1,6 +1,6 @@
 package com.kiero.schedule.application.dto;
 
-public record ScheduleUpdateEventTarget(
+public record ScheduleEventTarget(
 	Long childId,
 	Long parentId
 ) {

--- a/src/main/java/com/kiero/schedule/application/port/in/ScheduleSchedulerUseCase.java
+++ b/src/main/java/com/kiero/schedule/application/port/in/ScheduleSchedulerUseCase.java
@@ -9,5 +9,7 @@ public interface ScheduleSchedulerUseCase {
 
 	void bulkMarkAndPushEventIfUpdateExists(LocalDate today, LocalTime now);
 
+	void pushEventIfScheduleStart(LocalDate today, LocalTime now);
+
 	void deleteObsoleteNonRecurringSchedules();
 }

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
@@ -5,7 +5,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
-import com.kiero.schedule.application.dto.ScheduleUpdateEventTarget;
+import com.kiero.schedule.application.dto.ScheduleEventTarget;
 import com.kiero.schedule.domain.ScheduleDetail;
 
 public interface ScheduleDetailPersistencePort {
@@ -37,7 +37,7 @@ public interface ScheduleDetailPersistencePort {
 
 	void deleteScheduleDetail(ScheduleDetail scheduleDetail);
 
-	List<ScheduleUpdateEventTarget> findScheduleUpdateEventTarget(LocalDate today, LocalTime now);
+	List<ScheduleEventTarget> findScheduleUpdateEventTarget(LocalDate today, LocalTime now);
 
 	void bulkMarkPendingAsFailed(LocalDate today, LocalTime now);
 

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleDetailPersistencePort.java
@@ -39,6 +39,8 @@ public interface ScheduleDetailPersistencePort {
 
 	List<ScheduleEventTarget> findScheduleUpdateEventTarget(LocalDate today, LocalTime now);
 
+	List<ScheduleEventTarget> findScheduleStartEventTarget(LocalDate today, LocalTime now);
+
 	void bulkMarkPendingAsFailed(LocalDate today, LocalTime now);
 
 	void bulkMarkVerifiedAsCompleted(LocalDate today, LocalTime now);

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleSchedulerService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleSchedulerService.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.kiero.schedule.application.dto.ScheduleStatusUpdatedEvent;
-import com.kiero.schedule.application.dto.ScheduleUpdateEventTarget;
+import com.kiero.schedule.application.dto.ScheduleEventTarget;
 import com.kiero.schedule.application.port.in.ScheduleSchedulerUseCase;
 import com.kiero.schedule.application.port.out.DiscardedSchedulePersistencePort;
 import com.kiero.schedule.application.port.out.ScheduleDetailPersistencePort;
@@ -69,7 +69,7 @@ public class ScheduleSchedulerService implements ScheduleSchedulerUseCase {
 	@Override
 	@Transactional
 	public void bulkMarkAndPushEventIfUpdateExists(LocalDate today, LocalTime now) {
-		List<ScheduleUpdateEventTarget> targets = scheduleDetailPersistencePort.findScheduleUpdateEventTarget(today, now);
+		List<ScheduleEventTarget> targets = scheduleDetailPersistencePort.findScheduleUpdateEventTarget(today, now);
 
 		if (!targets.isEmpty()) {
 			scheduleDetailPersistencePort.bulkMarkPendingAsFailed(today, now);
@@ -77,8 +77,8 @@ public class ScheduleSchedulerService implements ScheduleSchedulerUseCase {
 
 			Map<Long, List<Long>> parentIdsByChildId = targets.stream()
 				.collect(Collectors.groupingBy(
-					ScheduleUpdateEventTarget::childId,
-					Collectors.mapping(ScheduleUpdateEventTarget::parentId, Collectors.toList())
+					ScheduleEventTarget::childId,
+					Collectors.mapping(ScheduleEventTarget::parentId, Collectors.toList())
 				));
 
 			for (var entry : parentIdsByChildId.entrySet()) {

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleSchedulerService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleSchedulerService.java
@@ -89,6 +89,24 @@ public class ScheduleSchedulerService implements ScheduleSchedulerUseCase {
 
 	@Override
 	@Transactional
+	public void pushEventIfScheduleStart(LocalDate today, LocalTime now) {
+		List<ScheduleEventTarget> targets = scheduleDetailPersistencePort.findScheduleStartEventTarget(today, now);
+
+		if (!targets.isEmpty()) {
+			Map<Long, List<Long>> parentIdsByChildId = targets.stream()
+				.collect(Collectors.groupingBy(
+					ScheduleEventTarget::childId,
+					Collectors.mapping(ScheduleEventTarget::parentId, Collectors.toList())
+				));
+
+			for (var entry : parentIdsByChildId.entrySet()) {
+				scheduleEventPort.publish(new ScheduleStatusUpdatedEvent(entry.getKey(), entry.getValue()));
+			}
+		}
+	}
+
+	@Override
+	@Transactional
 	public void deleteObsoleteNonRecurringSchedules() {
 		schedulePersistencePort.deleteObsoleteNonRecurringSchedules();
 	}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #215 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
시작시간이 지나, 일정이 '현재 진행' 상태가 되었을 때 이벤트를 발행하는 스케쥴링 로직을 추가하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

첫 번째 이벤트는 일정 시작으로 인한 이벤트, 두 번째 이벤트는 일정 종료로 인한 이벤트입니다.
<img width="852" height="673" alt="image" src="https://github.com/user-attachments/assets/1b5b3768-d4ce-4dbb-821b-b7055511bb0c" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
ScheduleStatus에 ONGOING(현재 진행 중 일정), DISCARDED(예외상황에 등록한 일정으로, 오늘은 무시되는 일정)을 추가하는 게 맞는데..... 마냥 소규모 리팩은 아니라서 리팩하다가 놓치는 부분이 있거나 사이드이펙트가 있을까봐 너므너므 무섭네요. 그래도 여유 생기는 대로 뚜따할 예정입니다. 

+ 그리고 Schedule은 차치하고, 유저와 schedule이 늘어날 때마다 ScheduleDetail은 쌓이는 데이터 양이 좀 많을 것 같아서 매월 한 번씩 스케쥴링으로 현재로부터 12주 이전의 scheduleDetail을 하드딜리트로 싹 날려버릴까 고민중인데 어떻게 생각하세요? (일정 탭에서 이전 12주까지 조회되어야 하는 것을 고려하였습니다.) 다른 엔티티나, feed 쪽도 scheduleDetail과 연관되어 있지 않아서 scheduleDetail이 삭제된다고 해도 문제는 없을 것 같습니다. 의견 남겨주시면 기획측에게 말해볼게요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정 시작 시점의 이벤트 발행 기능이 추가되었습니다.
  * 예약된 작업이 실행될 때마다 일정 시작 이벤트를 처리하도록 개선되었습니다.

* **리팩토링**
  * 이벤트 대상 데이터 구조가 통합되어 더욱 일관성 있게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->