### PR TITLE
[feat] #220 - GET api 일부에 캐싱 적용

### DIFF
--- a/src/main/java/com/kiero/coupon/application/service/CouponCacheEvictHelper.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCacheEvictHelper.java
@@ -1,5 +1,6 @@
 package com.kiero.coupon.application.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 
 import org.springframework.cache.Cache;
@@ -17,6 +18,7 @@ public class CouponCacheEvictHelper {
 	private static final String CACHE_NAME = "coupons";
 
 	private final CacheManager cacheManager;
+	private final Clock clock;
 
 	public void evictByChildId(Long childId) {
 		// 현재 스레드에 활성화된 트랜잭션이 있는지 확인
@@ -36,7 +38,7 @@ public class CouponCacheEvictHelper {
 	private void doEvict(Long childId) {
 		Cache cache = cacheManager.getCache(CACHE_NAME);
 		if (cache != null) {
-			cache.evict(childId + ":" + LocalDate.now());
+			cache.evict(childId + ":" + LocalDate.now(clock));
 		}
 	}
 }

--- a/src/main/java/com/kiero/coupon/application/service/CouponCacheEvictHelper.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCacheEvictHelper.java
@@ -3,6 +3,8 @@ package com.kiero.coupon.application.service;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +17,21 @@ public class CouponCacheEvictHelper {
 	private final CacheManager cacheManager;
 
 	public void evictByChildId(Long childId) {
+		// 현재 스레드에 활성화된 트랜잭션이 있는지 확인
+		if (TransactionSynchronizationManager.isActualTransactionActive()) {
+			// 트랜잭션이 커밋 성공했을 때 콜백(doEvict) 실행
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					doEvict(childId);
+				}
+			});
+		} else {
+			doEvict(childId);
+		}
+	}
+
+	private void doEvict(Long childId) {
 		Cache cache = cacheManager.getCache(CACHE_NAME);
 		if (cache != null) {
 			cache.evict(childId);

--- a/src/main/java/com/kiero/coupon/application/service/CouponCacheEvictHelper.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCacheEvictHelper.java
@@ -1,5 +1,7 @@
 package com.kiero.coupon.application.service;
 
+import java.time.LocalDate;
+
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
@@ -34,7 +36,7 @@ public class CouponCacheEvictHelper {
 	private void doEvict(Long childId) {
 		Cache cache = cacheManager.getCache(CACHE_NAME);
 		if (cache != null) {
-			cache.evict(childId);
+			cache.evict(childId + ":" + LocalDate.now());
 		}
 	}
 }

--- a/src/main/java/com/kiero/coupon/application/service/CouponCacheEvictHelper.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCacheEvictHelper.java
@@ -1,0 +1,23 @@
+package com.kiero.coupon.application.service;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CouponCacheEvictHelper {
+
+	private static final String CACHE_NAME = "coupons";
+
+	private final CacheManager cacheManager;
+
+	public void evictByChildId(Long childId) {
+		Cache cache = cacheManager.getCache(CACHE_NAME);
+		if (cache != null) {
+			cache.evict(childId);
+		}
+	}
+}

--- a/src/main/java/com/kiero/coupon/application/service/CouponCacheableService.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCacheableService.java
@@ -1,5 +1,7 @@
 package com.kiero.coupon.application.service;
 
+import java.time.Clock;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.cache.annotation.Cacheable;
@@ -16,13 +18,18 @@ import lombok.RequiredArgsConstructor;
 public class CouponCacheableService {
 
 	private final CouponLoadPort couponLoadPort;
+	private final Clock clock;
 
 	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "coupons", key = "#childId + ':' + T(java.time.LocalDate).now()", condition = "#childId != null")
+	@Cacheable(cacheNames = "coupons", key = "#root.target.cacheKey(#childId)", condition = "#childId != null")
 	public List<CouponResponse> getCouponsByChild(Long childId) {
 		return couponLoadPort.findAllByChildIdOrderByPriceAsc(childId)
 			.stream()
 			.map(CouponResponse::from)
 			.toList();
+	}
+
+	public String cacheKey(Long childId) {
+		return childId + ":" + LocalDate.now(clock);
 	}
 }

--- a/src/main/java/com/kiero/coupon/application/service/CouponCacheableService.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCacheableService.java
@@ -18,7 +18,7 @@ public class CouponCacheableService {
 	private final CouponLoadPort couponLoadPort;
 
 	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "coupons", key = "#childId", condition = "#childId != null")
+	@Cacheable(cacheNames = "coupons", key = "#childId + ':' + T(java.time.LocalDate).now()", condition = "#childId != null")
 	public List<CouponResponse> getCouponsByChild(Long childId) {
 		return couponLoadPort.findAllByChildIdOrderByPriceAsc(childId)
 			.stream()

--- a/src/main/java/com/kiero/coupon/application/service/CouponCacheableService.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCacheableService.java
@@ -1,0 +1,28 @@
+package com.kiero.coupon.application.service;
+
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.coupon.application.dto.CouponResponse;
+import com.kiero.coupon.application.port.out.CouponLoadPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CouponCacheableService {
+
+	private final CouponLoadPort couponLoadPort;
+
+	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "coupons", key = "#childId", condition = "#childId != null")
+	public List<CouponResponse> getCouponsByChild(Long childId) {
+		return couponLoadPort.findAllByChildIdOrderByPriceAsc(childId)
+			.stream()
+			.map(CouponResponse::from)
+			.toList();
+	}
+}

--- a/src/main/java/com/kiero/coupon/application/service/CouponCommandService.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCommandService.java
@@ -41,6 +41,8 @@ public class CouponCommandService implements CouponCommandUseCase {
 	private final CouponEventPort couponEventPort;
 	private final ParentChildLoadPort parentChildLoadPort;
 
+	private final CouponCacheEvictHelper couponCacheEvictHelper;
+
 	@Override
 	@Transactional
 	public CouponResponse createCoupon(Long parentId, Long childId, CouponCreateRequest request) {
@@ -58,6 +60,8 @@ public class CouponCommandService implements CouponCommandUseCase {
 		Coupon coupon = Coupon.create(request.name(), price, parent, child);
 		Coupon saved = couponPersistencePort.save(coupon);
 
+		couponCacheEvictHelper.evictByChildId(childId);
+
 		couponEventPort.publish(new CouponCreatedEvent(childId, saved.getName(), saved.getPrice()));
 
 		return CouponResponse.from(saved);
@@ -74,7 +78,10 @@ public class CouponCommandService implements CouponCommandUseCase {
 		}
 
 		int price = Math.min(request.price(), MAX_COUPON_PRICE);
+
 		coupon.update(request.name(), price);
+
+		couponCacheEvictHelper.evictByChildId(coupon.getChild().getId());
 
 		return CouponResponse.from(coupon);
 	}
@@ -88,6 +95,8 @@ public class CouponCommandService implements CouponCommandUseCase {
 		if (!coupon.getParent().getId().equals(parentId)) {
 			throw new KieroException(CouponErrorCode.NOT_YOUR_COUPON);
 		}
+
+		couponCacheEvictHelper.evictByChildId(coupon.getChild().getId());
 
 		couponPersistencePort.delete(coupon);
 	}

--- a/src/main/java/com/kiero/coupon/application/service/CouponQueryService.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponQueryService.java
@@ -2,6 +2,7 @@ package com.kiero.coupon.application.service;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class CouponQueryService implements CouponsQueryUseCase {
 
 	@Override
 	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "coupons", key = "#childId", condition = "#childId != null")
 	public List<CouponResponse> getCouponsByChild(Long childId) {
 		return couponLoadPort.findAllByChildIdOrderByPriceAsc(childId)
 			.stream()
@@ -32,6 +34,7 @@ public class CouponQueryService implements CouponsQueryUseCase {
 
 	@Override
 	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "coupons", key = "#childId", condition = "#childId != null")
 	public List<CouponResponse> getCouponsByParent(Long parentId, Long childId) {
 		if (!parentChildAccessPort.existsByParentIdAndChildId(parentId, childId)) {
 			throw new KieroException(CouponErrorCode.NOT_YOUR_CHILD);

--- a/src/main/java/com/kiero/coupon/application/service/CouponQueryService.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponQueryService.java
@@ -2,14 +2,11 @@ package com.kiero.coupon.application.service;
 
 import java.util.List;
 
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.kiero.coupon.application.dto.CouponResponse;
 import com.kiero.coupon.application.exception.CouponErrorCode;
 import com.kiero.coupon.application.port.in.CouponsQueryUseCase;
-import com.kiero.coupon.application.port.out.CouponLoadPort;
 import com.kiero.global.exception.KieroException;
 import com.kiero.parent.application.port.out.ParentChildAccessPort;
 
@@ -19,30 +16,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CouponQueryService implements CouponsQueryUseCase {
 
-	private final CouponLoadPort couponLoadPort;
+	private final CouponCacheableService couponCacheableService;
 	private final ParentChildAccessPort parentChildAccessPort;
 
 	@Override
-	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "coupons", key = "#childId", condition = "#childId != null")
 	public List<CouponResponse> getCouponsByChild(Long childId) {
-		return couponLoadPort.findAllByChildIdOrderByPriceAsc(childId)
-			.stream()
-			.map(CouponResponse::from)
-			.toList();
+		return couponCacheableService.getCouponsByChild(childId);
 	}
 
 	@Override
-	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "coupons", key = "#childId", condition = "#childId != null")
 	public List<CouponResponse> getCouponsByParent(Long parentId, Long childId) {
 		if (!parentChildAccessPort.existsByParentIdAndChildId(parentId, childId)) {
 			throw new KieroException(CouponErrorCode.NOT_YOUR_CHILD);
 		}
-
-		return couponLoadPort.findAllByChildIdOrderByPriceAsc(childId)
-			.stream()
-			.map(CouponResponse::from)
-			.toList();
+		return couponCacheableService.getCouponsByChild(childId);
 	}
 }

--- a/src/main/java/com/kiero/global/config/CacheConfig.java
+++ b/src/main/java/com/kiero/global/config/CacheConfig.java
@@ -28,7 +28,9 @@ public class CacheConfig {
 			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 			.activateDefaultTyping(
 				BasicPolymorphicTypeValidator.builder()
-					.allowIfBaseType(Object.class)
+					.allowIfSubType("com.kiero.")
+					.allowIfSubType("java.util.")
+					.allowIfSubType("java.time.")
 					.build(),
 				ObjectMapper.DefaultTyping.EVERYTHING
 			);

--- a/src/main/java/com/kiero/global/config/CacheConfig.java
+++ b/src/main/java/com/kiero/global/config/CacheConfig.java
@@ -31,6 +31,7 @@ public class CacheConfig {
 					.allowIfSubType("com.kiero.")
 					.allowIfSubType("java.util.")
 					.allowIfSubType("java.time.")
+					.allowIfSubType("java.lang.")
 					.build(),
 				ObjectMapper.DefaultTyping.EVERYTHING
 			);

--- a/src/main/java/com/kiero/global/config/CacheConfig.java
+++ b/src/main/java/com/kiero/global/config/CacheConfig.java
@@ -1,0 +1,50 @@
+package com.kiero.global.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+	@Bean
+	public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+		ObjectMapper objectMapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule())
+			.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+			.activateDefaultTyping(
+				BasicPolymorphicTypeValidator.builder()
+					.allowIfBaseType(Object.class)
+					.build(),
+				ObjectMapper.DefaultTyping.EVERYTHING
+			);
+
+		GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofMinutes(5)) // 만료시간 5분
+			.serializeKeysWith( // key는 String으로 직렬화
+				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith( // value는 json으로 직렬화
+				RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+			.disableCachingNullValues();
+
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(config)
+			.build();
+	}
+}

--- a/src/main/java/com/kiero/mission/application/service/MissionCacheEvictHelper.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCacheEvictHelper.java
@@ -1,5 +1,6 @@
 package com.kiero.mission.application.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 
 import org.springframework.cache.Cache;
@@ -17,6 +18,7 @@ public class MissionCacheEvictHelper {
 	private static final String CACHE_NAME = "missions";
 
 	private final CacheManager cacheManager;
+	private final Clock clock;
 
 	public void evictByChildId(Long childId) {
 		// 현재 스레드에 활성화된 트랜잭션이 있는지 확인
@@ -36,7 +38,7 @@ public class MissionCacheEvictHelper {
 	private void doEvict(Long childId) {
 		Cache cache = cacheManager.getCache(CACHE_NAME);
 		if (cache != null) {
-			cache.evict(childId + ":" + LocalDate.now());
+			cache.evict(childId + ":" + LocalDate.now(clock));
 		}
 	}
 }

--- a/src/main/java/com/kiero/mission/application/service/MissionCacheEvictHelper.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCacheEvictHelper.java
@@ -1,5 +1,7 @@
 package com.kiero.mission.application.service;
 
+import java.time.LocalDate;
+
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
@@ -34,7 +36,7 @@ public class MissionCacheEvictHelper {
 	private void doEvict(Long childId) {
 		Cache cache = cacheManager.getCache(CACHE_NAME);
 		if (cache != null) {
-			cache.evict(childId);
+			cache.evict(childId + ":" + LocalDate.now());
 		}
 	}
 }

--- a/src/main/java/com/kiero/mission/application/service/MissionCacheEvictHelper.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCacheEvictHelper.java
@@ -1,0 +1,23 @@
+package com.kiero.mission.application.service;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MissionCacheEvictHelper {
+
+	private static final String CACHE_NAME = "missions";
+
+	private final CacheManager cacheManager;
+
+	public void evictByChildId(Long childId) {
+		Cache cache = cacheManager.getCache(CACHE_NAME);
+		if (cache != null) {
+			cache.evict(childId);
+		}
+	}
+}

--- a/src/main/java/com/kiero/mission/application/service/MissionCacheEvictHelper.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCacheEvictHelper.java
@@ -3,6 +3,8 @@ package com.kiero.mission.application.service;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import lombok.RequiredArgsConstructor;
 
@@ -15,6 +17,21 @@ public class MissionCacheEvictHelper {
 	private final CacheManager cacheManager;
 
 	public void evictByChildId(Long childId) {
+		// 현재 스레드에 활성화된 트랜잭션이 있는지 확인
+		if (TransactionSynchronizationManager.isActualTransactionActive()) {
+			// 트랜잭션이 커밋 성공했을 때 콜백(doEvict) 실행
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					doEvict(childId);
+				}
+			});
+		} else {
+			doEvict(childId);
+		}
+	}
+
+	private void doEvict(Long childId) {
 		Cache cache = cacheManager.getCache(CACHE_NAME);
 		if (cache != null) {
 			cache.evict(childId);

--- a/src/main/java/com/kiero/mission/application/service/MissionCacheableService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCacheableService.java
@@ -1,5 +1,6 @@
 package com.kiero.mission.application.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -17,11 +18,12 @@ import lombok.RequiredArgsConstructor;
 public class MissionCacheableService {
 
 	private final MissionPersistencePort missionPort;
+	private final Clock clock;
 
 	@Transactional(readOnly = true)
 	@Cacheable(cacheNames = "missions", key = "#childId + ':' + T(java.time.LocalDate).now()", condition = "#childId != null")
 	public List<MissionResponse> getMissionsByChild(Long childId) {
-		LocalDate today = LocalDate.now();
+		LocalDate today = LocalDate.now(clock);
 		return missionPort.findAllByChildIdAndDueAtGreaterThanEqual(childId, today)
 			.stream().map(MissionResponse::from).toList();
 	}

--- a/src/main/java/com/kiero/mission/application/service/MissionCacheableService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCacheableService.java
@@ -1,0 +1,28 @@
+package com.kiero.mission.application.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.mission.application.dto.MissionResponse;
+import com.kiero.mission.application.port.out.MissionPersistencePort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MissionCacheableService {
+
+	private final MissionPersistencePort missionPort;
+
+	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "missions", key = "#childId", condition = "#childId != null")
+	public List<MissionResponse> getMissionsByChild(Long childId) {
+		LocalDate today = LocalDate.now();
+		return missionPort.findAllByChildIdAndDueAtGreaterThanEqual(childId, today)
+			.stream().map(MissionResponse::from).toList();
+	}
+}

--- a/src/main/java/com/kiero/mission/application/service/MissionCacheableService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCacheableService.java
@@ -19,7 +19,7 @@ public class MissionCacheableService {
 	private final MissionPersistencePort missionPort;
 
 	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "missions", key = "#childId", condition = "#childId != null")
+	@Cacheable(cacheNames = "missions", key = "#childId + ':' + T(java.time.LocalDate).now()", condition = "#childId != null")
 	public List<MissionResponse> getMissionsByChild(Long childId) {
 		LocalDate today = LocalDate.now();
 		return missionPort.findAllByChildIdAndDueAtGreaterThanEqual(childId, today)

--- a/src/main/java/com/kiero/mission/application/service/MissionCacheableService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCacheableService.java
@@ -21,10 +21,14 @@ public class MissionCacheableService {
 	private final Clock clock;
 
 	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "missions", key = "#childId + ':' + T(java.time.LocalDate).now()", condition = "#childId != null")
+	@Cacheable(cacheNames = "missions", key = "#root.target.cacheKey(#childId)", condition = "#childId != null")
 	public List<MissionResponse> getMissionsByChild(Long childId) {
 		LocalDate today = LocalDate.now(clock);
 		return missionPort.findAllByChildIdAndDueAtGreaterThanEqual(childId, today)
 			.stream().map(MissionResponse::from).toList();
+	}
+
+	public String cacheKey(Long childId) {
+		return childId + ":" + LocalDate.now(clock);
 	}
 }

--- a/src/main/java/com/kiero/mission/application/service/MissionCommandService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCommandService.java
@@ -48,6 +48,8 @@ public class MissionCommandService implements MissionCommandUseCase {
 	private final ChildLoadPort childLoadPort;
 	private final ParentChildLoadPort parentChildLoadPort;
 
+	private final MissionCacheEvictHelper missionCacheEvictHelper;
+
 	@Override
 	@Transactional
 	public MissionResponse createMission(Long parentId, Long childId, MissionCreateRequest request) {
@@ -74,6 +76,8 @@ public class MissionCommandService implements MissionCommandUseCase {
 			mission.getName(),
 			mission.getReward()
 		));
+
+		missionCacheEvictHelper.evictByChildId(childId);
 
 		log.info("Mission created: missionId={}, parentId={}, childId={}, name={}",
 			saved.getId(), parentId, childId, request.name());
@@ -102,6 +106,8 @@ public class MissionCommandService implements MissionCommandUseCase {
 		for (Mission m : saved) {
 			eventPort.publish(new MissionCreatedEvent(childId, m.getName(), m.getReward()));
 		}
+
+		missionCacheEvictHelper.evictByChildId(childId);
 
 		log.info("Bulk created {} missions for parentId={}, childId={}", saved.size(), parentId, childId);
 
@@ -150,6 +156,8 @@ public class MissionCommandService implements MissionCommandUseCase {
 			eventPort.publish(new MissionCompleteEvent(parentIds, childId));
 		}
 
+		missionCacheEvictHelper.evictByChildId(childId);
+
 		log.info("Mission completed: missionId={}, childId={}, reward={}, newCoinAmount={}",
 			missionId, childId, mission.getReward(), child.getCoinAmount());
 
@@ -172,6 +180,8 @@ public class MissionCommandService implements MissionCommandUseCase {
 
 		mission.update(request.name(), request.reward(), request.dueAt());
 
+		missionCacheEvictHelper.evictByChildId(mission.getChild().getId());
+
 		return MissionUpdateResponse.from(mission);
 	}
 
@@ -189,7 +199,9 @@ public class MissionCommandService implements MissionCommandUseCase {
 			throw new KieroException(MissionErrorCode.MISSION_ALREADY_COMPLETED);
 		}
 
+		Long childId = mission.getChild().getId();
 		missionPort.delete(mission);
+		missionCacheEvictHelper.evictByChildId(childId);
 	}
 
 	private void validateParentChildRelation(Long parentId, Long childId) {

--- a/src/main/java/com/kiero/mission/application/service/MissionQueryService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionQueryService.java
@@ -15,6 +15,8 @@ import com.kiero.mission.application.port.out.MissionPersistencePort;
 import com.kiero.mission.domain.Mission;
 import com.kiero.parent.application.port.out.ParentChildAccessPort;
 
+import org.springframework.cache.annotation.Cacheable;
+
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -27,6 +29,7 @@ public class MissionQueryService implements MissionQueryUseCase {
 
 	@Override
 	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "missions", key = "#childId", condition = "#childId != null")
 	public List<MissionResponse> getMissionsByParent(Long parentId, Long childId) {
 		LocalDate today = LocalDate.now();
 
@@ -46,6 +49,7 @@ public class MissionQueryService implements MissionQueryUseCase {
 
 	@Override
 	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "missions", key = "#childId")
 	public List<MissionResponse> getMissionsByChild(Long childId) {
 		LocalDate today = LocalDate.now();
 		return missionPort.findAllByChildIdAndDueAtGreaterThanEqual(childId, today)

--- a/src/main/java/com/kiero/mission/application/service/MissionQueryService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionQueryService.java
@@ -15,8 +15,6 @@ import com.kiero.mission.application.port.out.MissionPersistencePort;
 import com.kiero.mission.domain.Mission;
 import com.kiero.parent.application.port.out.ParentChildAccessPort;
 
-import org.springframework.cache.annotation.Cacheable;
-
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -24,36 +22,28 @@ import lombok.RequiredArgsConstructor;
 public class MissionQueryService implements MissionQueryUseCase {
 
 	private final MissionPersistencePort missionPort;
-
+	private final MissionCacheableService missionCacheableService;
 	private final ParentChildAccessPort parentChildAccessPort;
 
 	@Override
-	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "missions", key = "#childId", condition = "#childId != null")
 	public List<MissionResponse> getMissionsByParent(Long parentId, Long childId) {
-		LocalDate today = LocalDate.now();
-
 		// 1. 특정 자녀 조회
 		if (childId != null) {
 			if (!parentChildAccessPort.existsByParentIdAndChildId(parentId, childId)) {
 				throw new KieroException(MissionErrorCode.NOT_YOUR_CHILD);
 			}
-			return missionPort.findAllByChildIdAndDueAtGreaterThanEqual(childId, today)
-				.stream().map(MissionResponse::from).toList();
+			return missionCacheableService.getMissionsByChild(childId);
 		}
 
-		// 2. 전체 자녀 조회
+		// 2. 전체 자녀 조회 (캐시 미적용)
+		LocalDate today = LocalDate.now();
 		return missionPort.findAllByParentIdAndDueAtGreaterThanEqual(parentId, today)
 			.stream().map(MissionResponse::from).toList();
 	}
 
 	@Override
-	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "missions", key = "#childId")
 	public List<MissionResponse> getMissionsByChild(Long childId) {
-		LocalDate today = LocalDate.now();
-		return missionPort.findAllByChildIdAndDueAtGreaterThanEqual(childId, today)
-			.stream().map(MissionResponse::from).toList();
+		return missionCacheableService.getMissionsByChild(childId);
 	}
 
 	@Override

--- a/src/main/java/com/kiero/schedule/adapter/in/event/ScheduleCacheEvictListener.java
+++ b/src/main/java/com/kiero/schedule/adapter/in/event/ScheduleCacheEvictListener.java
@@ -1,0 +1,43 @@
+package com.kiero.schedule.adapter.in.event;
+
+import java.util.Set;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.kiero.schedule.application.dto.ScheduleModifiedEvent;
+import com.kiero.schedule.application.dto.ScheduleStatusUpdatedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ScheduleCacheEvictListener {
+
+	private static final String CACHE_KEY_PREFIX = "schedules::";
+
+	private final StringRedisTemplate stringRedisTemplate;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(ScheduleModifiedEvent event) {
+		evictByChildId(event.childId());
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(ScheduleStatusUpdatedEvent event) {
+		evictByChildId(event.childId());
+	}
+
+	private void evictByChildId(Long childId) {
+		String pattern = CACHE_KEY_PREFIX + childId + ":*";
+		Set<String> keys = stringRedisTemplate.keys(pattern);
+		if (!keys.isEmpty()) {
+			stringRedisTemplate.delete(keys);
+			log.debug("[ScheduleCacheEvict] childId={} 캐시 {}건 삭제", childId, keys.size());
+		}
+	}
+}

--- a/src/main/java/com/kiero/schedule/adapter/in/event/ScheduleCacheEvictListener.java
+++ b/src/main/java/com/kiero/schedule/adapter/in/event/ScheduleCacheEvictListener.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import com.kiero.schedule.application.dto.FireLitEvent;
+import com.kiero.schedule.application.dto.ScheduleCacheEvent;
 import com.kiero.schedule.application.dto.ScheduleModifiedEvent;
 import com.kiero.schedule.application.dto.ScheduleStatusUpdatedEvent;
 
@@ -23,6 +25,11 @@ public class ScheduleCacheEvictListener {
 	private final StringRedisTemplate stringRedisTemplate;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(ScheduleCacheEvent event) {
+		evictByChildId(event.childId());
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(ScheduleModifiedEvent event) {
 		evictByChildId(event.childId());
 	}
@@ -31,6 +38,9 @@ public class ScheduleCacheEvictListener {
 	public void handle(ScheduleStatusUpdatedEvent event) {
 		evictByChildId(event.childId());
 	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(FireLitEvent event) { evictByChildId(event.childId());}
 
 	private void evictByChildId(Long childId) {
 		String pattern = CACHE_KEY_PREFIX + childId + ":*";

--- a/src/main/java/com/kiero/schedule/adapter/in/event/ScheduleCacheEvictListener.java
+++ b/src/main/java/com/kiero/schedule/adapter/in/event/ScheduleCacheEvictListener.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.kiero.schedule.application.dto.FireLitEvent;
 import com.kiero.schedule.application.dto.ScheduleCacheEvent;
-import com.kiero.schedule.application.dto.ScheduleModifiedEvent;
 import com.kiero.schedule.application.dto.ScheduleStatusUpdatedEvent;
 
 import lombok.RequiredArgsConstructor;
@@ -25,14 +24,7 @@ public class ScheduleCacheEvictListener {
 	private final StringRedisTemplate stringRedisTemplate;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handle(ScheduleCacheEvent event) {
-		evictByChildId(event.childId());
-	}
-
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-	public void handle(ScheduleModifiedEvent event) {
-		evictByChildId(event.childId());
-	}
+	public void handle(ScheduleCacheEvent event) { evictByChildId(event.childId()); }
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(ScheduleStatusUpdatedEvent event) {

--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleCacheEvent.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleCacheEvent.java
@@ -1,0 +1,6 @@
+package com.kiero.schedule.application.dto;
+
+public record ScheduleCacheEvent(
+	Long childId
+) {
+}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCacheableService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCacheableService.java
@@ -37,7 +37,7 @@ public class ScheduleCacheableService {
 	private final ScheduleDetailPersistencePort scheduleDetailPersistencePort;
 	private final Clock clock;
 
-	@Transactional
+	@Transactional(readOnly = true)
 	@Cacheable(cacheNames = "schedules", key = "#childId + ':' + #startDate + ':' + #endDate")
 	public ScheduleOccurrencesResponse getSchedules(LocalDate startDate, LocalDate endDate, Long childId) {
 		List<Schedule> schedules = schedulePersistencePort.findAllByChildId(childId);

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCacheableService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCacheableService.java
@@ -1,0 +1,164 @@
+package com.kiero.schedule.application.service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.schedule.application.dto.ScheduleOccurrenceDto;
+import com.kiero.schedule.application.dto.ScheduleOccurrencesResponse;
+import com.kiero.schedule.application.port.out.DiscardedSchedulePersistencePort;
+import com.kiero.schedule.application.port.out.ScheduleDetailPersistencePort;
+import com.kiero.schedule.application.port.out.SchedulePersistencePort;
+import com.kiero.schedule.application.port.out.ScheduleRepeatDaysPersistencePort;
+import com.kiero.schedule.domain.Schedule;
+import com.kiero.schedule.domain.ScheduleDetail;
+import com.kiero.schedule.domain.ScheduleRepeatDays;
+import com.kiero.schedule.domain.enums.DayOfWeek;
+import com.kiero.schedule.domain.enums.ScheduleStatus;
+import com.kiero.schedule.domain.vo.DiscardKey;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleCacheableService {
+
+	private final SchedulePersistencePort schedulePersistencePort;
+	private final ScheduleRepeatDaysPersistencePort scheduleRepeatDaysPersistencePort;
+	private final DiscardedSchedulePersistencePort discardedSchedulePersistencePort;
+	private final ScheduleDetailPersistencePort scheduleDetailPersistencePort;
+	private final Clock clock;
+
+	@Transactional
+	@Cacheable(cacheNames = "schedules", key = "#childId + ':' + #startDate + ':' + #endDate")
+	public ScheduleOccurrencesResponse getSchedules(LocalDate startDate, LocalDate endDate, Long childId) {
+		List<Schedule> schedules = schedulePersistencePort.findAllByChildId(childId);
+		if (schedules.isEmpty()) {
+			return ScheduleOccurrencesResponse.of(false, List.of());
+		}
+
+		boolean isFireLitToday = scheduleDetailPersistencePort.existsStoneUsedTodayByChildIdAndDate(childId, LocalDate.now(clock));
+
+		LocalDate today = LocalDate.now(clock);
+
+		Set<DiscardKey> discardedKeys = discardedSchedulePersistencePort
+			.findAllByChildIdAndDateBetween(childId, startDate, endDate).stream()
+			.map(ds -> new DiscardKey(ds.getSchedule().getId(), ds.getDate()))
+			.collect(Collectors.toSet());
+
+		List<Long> recurringIds = schedules.stream()
+			.filter(Schedule::isRecurring)
+			.map(Schedule::getId)
+			.toList();
+
+		Map<Long, List<DayOfWeek>> repeatDaysByScheduleId = Map.of();
+		if (!recurringIds.isEmpty()) {
+			List<ScheduleRepeatDays> repeatDays = scheduleRepeatDaysPersistencePort.findAllByScheduleIdsIn(recurringIds);
+			repeatDaysByScheduleId = repeatDays.stream()
+				.collect(Collectors.groupingBy(
+					rd -> rd.getSchedule().getId(),
+					Collectors.mapping(ScheduleRepeatDays::getDayOfWeek, Collectors.toList())
+				));
+		}
+
+		List<Long> normalIds = schedules.stream()
+			.filter(s -> !s.isRecurring())
+			.map(Schedule::getId)
+			.toList();
+
+		Map<Long, Schedule> scheduleById = schedules.stream().collect(Collectors.toMap(Schedule::getId, s -> s));
+
+		List<ScheduleOccurrenceDto> items = new java.util.ArrayList<>();
+
+		Map<Long, ScheduleDetail> todayScheduleDetailByScheduleId = Map.of();
+		if (!today.isBefore(startDate) && !today.isAfter(endDate)) {
+			todayScheduleDetailByScheduleId = scheduleDetailPersistencePort.findByDateAndChildId(today, childId).stream()
+				.collect(Collectors.toMap(
+					sd -> sd.getSchedule().getId(),
+					sd -> sd
+				));
+		}
+
+		if (!normalIds.isEmpty()) {
+			List<ScheduleDetail> details = scheduleDetailPersistencePort.findAllByScheduleIdInAndDateBetween(normalIds, startDate, endDate);
+
+			for (ScheduleDetail d : details) {
+				Schedule s = scheduleById.get(d.getSchedule().getId());
+				ScheduleStatus todayScheduleStatus = d.getDate().isEqual(today) ? d.getScheduleStatus() : null;
+
+				if (discardedKeys.contains(new DiscardKey(s.getId(), d.getDate())))
+					continue;
+
+				items.add(new ScheduleOccurrenceDto(
+					s.getId(),
+					d.getDate(),
+					List.of(),
+					todayScheduleStatus,
+					s.getStartTime(),
+					s.getEndTime(),
+					s.getName(),
+					s.getScheduleColor().getColorCode()
+				));
+			}
+		}
+
+		for (Schedule s : schedules) {
+			if (!s.isRecurring())
+				continue;
+
+			List<DayOfWeek> repeatDays = repeatDaysByScheduleId.getOrDefault(s.getId(), List.of());
+			if (repeatDays.isEmpty())
+				continue;
+
+			LocalDate repeatStart = s.getRepeatStartDate();
+			LocalDate repeatEnd = s.getRepeatEndDate();
+
+			for (LocalDate cursor = startDate; !cursor.isAfter(endDate); cursor = cursor.plusDays(1)) {
+				if (repeatStart != null && cursor.isBefore(repeatStart))
+					continue;
+				if (repeatEnd != null && cursor.isAfter(repeatEnd))
+					continue;
+
+				DayOfWeek cursorDow = DayOfWeek.from(cursor.getDayOfWeek());
+				if (!repeatDays.contains(cursorDow))
+					continue;
+
+				if (discardedKeys.contains(new DiscardKey(s.getId(), cursor)))
+					continue;
+
+				ScheduleStatus todayScheduleStatus = null;
+				if (cursor.isEqual(today)) {
+					ScheduleDetail todayDetail = todayScheduleDetailByScheduleId.get(s.getId());
+					todayScheduleStatus = todayDetail != null ? todayDetail.getScheduleStatus() : null;
+				}
+
+				items.add(new ScheduleOccurrenceDto(
+					s.getId(),
+					cursor,
+					repeatDays,
+					todayScheduleStatus,
+					s.getStartTime(),
+					s.getEndTime(),
+					s.getName(),
+					s.getScheduleColor().getColorCode()
+				));
+			}
+		}
+
+		items.sort(
+			Comparator.comparing(ScheduleOccurrenceDto::date)
+				.thenComparing(ScheduleOccurrenceDto::startTime)
+				.thenComparing(ScheduleOccurrenceDto::scheduleId)
+		);
+
+		return ScheduleOccurrencesResponse.of(isFireLitToday, items);
+	}
+}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -30,6 +30,7 @@ import com.kiero.schedule.application.dto.FireLitResponse;
 import com.kiero.schedule.application.dto.NowScheduleCompleteEventForFeed;
 import com.kiero.schedule.application.dto.NowScheduleCompleteRequest;
 import com.kiero.schedule.application.dto.ScheduleAddRequest;
+import com.kiero.schedule.application.dto.ScheduleCacheEvent;
 import com.kiero.schedule.application.dto.ScheduleDeleteRequest;
 import com.kiero.schedule.application.dto.ScheduleModifiedEvent;
 import com.kiero.schedule.application.dto.ScheduleModifyRequest;
@@ -65,7 +66,6 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 	private final ChildLoadPort childLoadPort;
 	private final ParentChildAccessPort parentChildAccessPort;
 
-	private final ScheduleEventPort eventPort;
 	private final Clock clock;
 
 	private final SchedulePersistencePort schedulePersistencePort;
@@ -177,8 +177,10 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			}
 		}
 
-		// 아이의 오늘 일정에 영향이 있을 때만 이벤트 전송
-		if (isEffectsToChildSchedule) eventPort.publish(new ScheduleModifiedEvent(childId));
+		// 아이의 오늘 일정에 영향이 있을 때만 SSE 이벤트 전송
+		if (isEffectsToChildSchedule) scheduleEventPort.publish(new ScheduleModifiedEvent(childId));
+
+		scheduleEventPort.publish(new ScheduleCacheEvent(childId));
 	}
 
 
@@ -237,7 +239,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			.map(Parent::getId)
 			.toList();
 
-		eventPort.publish(new NowScheduleCompleteEventForFeed(
+		scheduleEventPort.publish(new NowScheduleCompleteEventForFeed(
 			parents,
 			scheduleDetail.getSchedule().getChild().getId(),
 			scheduleDetail.getId(),
@@ -291,8 +293,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			.map(Parent::getId)
 			.toList();
 
-		eventPort.publish(new FireLitEvent(parentIds, child.getId()));
-		eventPort.publish(new FireLitEventForFeed(parents, child.getId(), earnedCoinAmount, LocalDateTime.now(clock)));
+		scheduleEventPort.publish(new FireLitEvent(parentIds, child.getId()));
+		scheduleEventPort.publish(new FireLitEventForFeed(parents, child.getId(), earnedCoinAmount, LocalDateTime.now(clock)));
 		return FireLitResponse.of(gotStones, earnedCoinAmount);
 	}
 
@@ -675,8 +677,10 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			default -> throw new KieroException(ScheduleErrorCode.SCHEDULE_UPDATE_CASE_CANNOT_RESOLVED);
 		}
 
-		// 아이의 오늘 일정에 영향이 있을 때만 이벤트 전송
-		if (isEffectsToChildSchedule) eventPort.publish(new ScheduleModifiedEvent(childId));
+		// 아이의 오늘 일정에 영향이 있을 때만 SSE 이벤트 전송
+		if (isEffectsToChildSchedule) scheduleEventPort.publish(new ScheduleModifiedEvent(childId));
+
+		scheduleEventPort.publish(new ScheduleCacheEvent(childId));
 	}
 
 	@Override
@@ -739,7 +743,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 					scheduleDetailPersistencePort.deleteScheduleDetail(scheduleDetail.get());
 
-					eventPort.publish(new ScheduleModifiedEvent(childId));
+					scheduleEventPort.publish(new ScheduleModifiedEvent(childId));
 					recalculateTodayStoneTypes(childId);
 				}
 				else {
@@ -758,7 +762,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 
 					scheduleDetailPersistencePort.deleteScheduleDetail(scheduleDetail.get());
 
-					eventPort.publish(new ScheduleModifiedEvent(childId));
+					scheduleEventPort.publish(new ScheduleModifiedEvent(childId));
 					recalculateTodayStoneTypes(childId);
 				}
 				else {
@@ -775,7 +779,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			else if ( isPending && isBeforeStart && !isExistsTodayNotPendingAfterEndTime) {
 				scheduleDetailPersistencePort.deleteByScheduleIdAndDate(originalSchedule.getId(), selectedDate);
 
-				eventPort.publish(new ScheduleModifiedEvent(childId));
+				scheduleEventPort.publish(new ScheduleModifiedEvent(childId));
 				recalculateTodayStoneTypes(childId);
 			}
 			else {
@@ -783,6 +787,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			}
 
 		}
+
+		scheduleEventPort.publish(new ScheduleCacheEvent(childId));
 	}
 
 	protected void calculateStoneTypePerScheduleDetail(List<ScheduleDetail> scheduleDetails) {

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
@@ -44,6 +44,8 @@ import com.kiero.schedule.domain.enums.ScheduleColor;
 import com.kiero.schedule.domain.enums.ScheduleStatus;
 import com.kiero.schedule.domain.vo.DiscardKey;
 
+import org.springframework.cache.annotation.Cacheable;
+
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -77,6 +79,7 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 
 	@Override
 	@Transactional
+	@Cacheable(cacheNames = "schedules", key = "#childId + ':' + #startDate + ':' + #endDate")
 	public ScheduleOccurrencesResponse getSchedules(LocalDate startDate, LocalDate endDate, Long parentId,
 		Long childId) {
 		checkIsExistsAndAccessibleByParentIdAndChildId(parentId, childId);

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -22,7 +21,6 @@ import com.kiero.parent.application.port.out.ParentLoadPort;
 import com.kiero.parent.domain.Parent;
 import com.kiero.schedule.application.dto.DefaultScheduleContentResponse;
 import com.kiero.schedule.application.dto.ScheduleDetailImageResponse;
-import com.kiero.schedule.application.dto.ScheduleOccurrenceDto;
 import com.kiero.schedule.application.dto.ScheduleOccurrencesResponse;
 import com.kiero.schedule.application.dto.ScheduleProgressForChildDto;
 import com.kiero.schedule.application.dto.ScheduleProgressForChildResponse;
@@ -33,18 +31,13 @@ import com.kiero.schedule.application.port.in.ScheduleQueryUseCase;
 import com.kiero.schedule.application.port.out.DiscardedSchedulePersistencePort;
 import com.kiero.schedule.application.port.out.ScheduleDetailPersistencePort;
 import com.kiero.schedule.application.port.out.SchedulePersistencePort;
-import com.kiero.schedule.application.port.out.ScheduleRepeatDaysPersistencePort;
 import com.kiero.schedule.application.service.resolver.TodayScheduleStatus;
 import com.kiero.schedule.application.service.resolver.TodayScheduleStatusResolver;
 import com.kiero.schedule.domain.Schedule;
 import com.kiero.schedule.domain.ScheduleDetail;
-import com.kiero.schedule.domain.ScheduleRepeatDays;
-import com.kiero.schedule.domain.enums.DayOfWeek;
 import com.kiero.schedule.domain.enums.ScheduleColor;
 import com.kiero.schedule.domain.enums.ScheduleStatus;
 import com.kiero.schedule.domain.vo.DiscardKey;
-
-import org.springframework.cache.annotation.Cacheable;
 
 import lombok.RequiredArgsConstructor;
 
@@ -57,10 +50,9 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 	private final ParentChildAccessPort parentChildAccessPort;
 
 	private final SchedulePersistencePort schedulePersistencePort;
-	private final ScheduleRepeatDaysPersistencePort scheduleRepeatDaysPersistencePort;
 	private final DiscardedSchedulePersistencePort discardedSchedulePersistencePort;
 	private final ScheduleDetailPersistencePort scheduleDetailPersistencePort;
-
+	private final ScheduleCacheableService scheduleCacheableService;
 
 	private final Clock clock;
 
@@ -78,148 +70,11 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 	}
 
 	@Override
-	@Transactional
-	@Cacheable(cacheNames = "schedules", key = "#childId + ':' + #startDate + ':' + #endDate")
 	public ScheduleOccurrencesResponse getSchedules(LocalDate startDate, LocalDate endDate, Long parentId,
 		Long childId) {
 		checkIsExistsAndAccessibleByParentIdAndChildId(parentId, childId);
-
 		validateScheduleRange(startDate, endDate);
-
-		List<Schedule> schedules = schedulePersistencePort.findAllByChildId(childId);
-		if (schedules.isEmpty()) {
-			return ScheduleOccurrencesResponse.of(false, List.of());
-		}
-
-		boolean isFireLitToday = scheduleDetailPersistencePort.existsStoneUsedTodayByChildIdAndDate(childId, LocalDate.now(clock));
-
-		LocalDate today = LocalDate.now(clock);
-
-		// 반복일정 일회성 수정, 일회성 삭제 등으로 인해 무시되어야 하는 일정 집합
-		Set<DiscardKey> discardedKeys = discardedSchedulePersistencePort
-			.findAllByChildIdAndDateBetween(childId, startDate, endDate).stream()
-			.map(ds -> new DiscardKey(ds.getSchedule().getId(), ds.getDate()))
-			.collect(Collectors.toSet());
-
-		// 반복일정 가져오기
-		List<Long> recurringIds = schedules.stream()
-			.filter(Schedule::isRecurring)
-			.map(Schedule::getId)
-			.toList();
-
-		Map<Long, List<DayOfWeek>> repeatDaysByScheduleId = Map.of();
-		if (!recurringIds.isEmpty()) {
-			List<ScheduleRepeatDays> repeatDays = scheduleRepeatDaysPersistencePort.findAllByScheduleIdsIn(recurringIds);
-
-			repeatDaysByScheduleId = repeatDays.stream()
-				.collect(Collectors.groupingBy(
-					rd -> rd.getSchedule().getId(),
-					Collectors.mapping(ScheduleRepeatDays::getDayOfWeek, Collectors.toList())
-				));
-		}
-
-		// 단일일정 가져오기
-		List<Long> normalIds = schedules.stream()
-			.filter(s -> !s.isRecurring())
-			.map(Schedule::getId)
-			.toList();
-
-		Map<Long, Schedule> scheduleById = schedules.stream().collect(Collectors.toMap(Schedule::getId, s -> s));
-
-		List<ScheduleOccurrenceDto> items = new java.util.ArrayList<>();
-
-		// 오늘 일정들의 scheduleDetail 가져오기
-		Map<Long, ScheduleDetail> todayScheduleDetailByScheduleId = Map.of();
-		if (!today.isBefore(startDate) && !today.isAfter(endDate)) {
-			todayScheduleDetailByScheduleId = scheduleDetailPersistencePort.findByDateAndChildId(today, childId).stream()
-				.collect(Collectors.toMap(
-					sd -> sd.getSchedule().getId(),
-					sd -> sd
-				));
-		}
-
-		// 단일일정들 dto화
-		if (!normalIds.isEmpty()) {
-			List<ScheduleDetail> details = scheduleDetailPersistencePort.findAllByScheduleIdInAndDateBetween(normalIds, startDate,
-				endDate);
-
-			for (ScheduleDetail d : details) {
-				Schedule s = scheduleById.get(d.getSchedule().getId());
-				ScheduleStatus todayScheduleStatus = d.getDate().isEqual(today) ? d.getScheduleStatus() : null;
-
-				// discarded 된 건 제외
-				if (discardedKeys.contains(new DiscardKey(s.getId(), d.getDate())))
-					continue;
-
-				items.add(new ScheduleOccurrenceDto(
-					s.getId(),
-					d.getDate(),
-					List.of(),
-					todayScheduleStatus,
-					s.getStartTime(),
-					s.getEndTime(),
-					s.getName(),
-					s.getScheduleColor().getColorCode()
-				));
-			}
-		}
-
-		// 반복 일정 dto화
-		for (Schedule s : schedules) {
-			if (!s.isRecurring())
-				continue;
-
-			List<DayOfWeek> repeatDays = repeatDaysByScheduleId.getOrDefault(s.getId(), List.of());
-			if (repeatDays.isEmpty())
-				continue;
-
-			LocalDate repeatStart = s.getRepeatStartDate();
-			LocalDate repeatEnd = s.getRepeatEndDate();
-
-			for (LocalDate cursor = startDate; !cursor.isAfter(endDate); cursor = cursor.plusDays(1)) {
-
-				// 기간 조건
-				if (repeatStart != null && cursor.isBefore(repeatStart))
-					continue;
-				if (repeatEnd != null && cursor.isAfter(repeatEnd))
-					continue;
-
-				// 요일 조건
-				DayOfWeek cursorDow = DayOfWeek.from(cursor.getDayOfWeek());
-				if (!repeatDays.contains(cursorDow))
-					continue;
-
-				// discarded 제외
-				if (discardedKeys.contains(new DiscardKey(s.getId(), cursor)))
-					continue;
-
-				ScheduleStatus todayScheduleStatus = null;
-				if (cursor.isEqual(today)) {
-					ScheduleDetail todayDetail = todayScheduleDetailByScheduleId.get(s.getId());
-					todayScheduleStatus = todayDetail != null ? todayDetail.getScheduleStatus() : null;
-				}
-
-				items.add(new ScheduleOccurrenceDto(
-					s.getId(),
-					cursor,
-					repeatDays,
-					todayScheduleStatus,
-					s.getStartTime(),
-					s.getEndTime(),
-					s.getName(),
-					s.getScheduleColor().getColorCode()
-				));
-			}
-		}
-
-		// date 순으로 정렬. 같은 date 내에서는 startTime, scheduleId 순으로 정렬
-		items.sort(
-			Comparator.comparing(ScheduleOccurrenceDto::date)
-				.thenComparing(ScheduleOccurrenceDto::startTime)
-				.thenComparing(ScheduleOccurrenceDto::scheduleId)
-		);
-
-		return ScheduleOccurrencesResponse.of(isFireLitToday, items);
+		return scheduleCacheableService.getSchedules(startDate, endDate, childId);
 	}
 
 	@Override

--- a/src/test/java/com/kiero/mission/service/MissionServiceTest.java
+++ b/src/test/java/com/kiero/mission/service/MissionServiceTest.java
@@ -30,6 +30,7 @@ import com.kiero.mission.application.dto.MissionResponse;
 import com.kiero.mission.application.exception.MissionErrorCode;
 import com.kiero.mission.application.port.out.MissionEventPort;
 import com.kiero.mission.application.port.out.MissionPersistencePort;
+import com.kiero.mission.application.service.MissionCacheEvictHelper;
 import com.kiero.mission.application.service.MissionCommandService;
 import com.kiero.mission.domain.Mission;
 import com.kiero.parent.application.exception.ParentErrorCode;
@@ -53,6 +54,8 @@ public class MissionServiceTest {
 	MissionEventPort missionEventPort;
 	@Mock
 	ParentChildLoadPort parentChildLoadPort;
+	@Mock
+	MissionCacheEvictHelper missionCacheEvictHelper;
 
 	@InjectMocks
 	MissionCommandService missionCommandService;


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #220 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

cacheManager를 사용해 일정 탭 조회, 미션 탭 조회(부모/아이), 쿠폰 탭 조회(부모/아이)에 캐싱을 적용하였습니다.
아래 적어놓은 것처럼 일정 탭 조회에서는 유의미한 응답속도 감소율을 확인하였는데, 미션이나 쿠폰 탭 조회에서는 큰 차이가 없었습니다. 애초에 join 연산 등이 없기 때문이겠지만, 부모와 아이가 같은 응답을 공유하니 히트율이 높을 것 같아 캐싱 적용 해보았습니다. 

일정 관련해서는 일정의 수정/삭제가 이루어지거나 일정의 상태가 바뀌었을 때, 기존 존재하는 event들의 리스너를 만들어 키를 삭제합니다. 미션, 쿠폰은 수정/삭제 service 로직 내에서 직접 key를 삭제하도록 메서드를 호출합니다.  _일정의 경우, 이미 수정/삭제/상태 변경을 모두 커버할 수 있는 event가 있어 after commit을 공짜로 보장할 수 있기 때문입니다._ (=> 미션, 쿠폰도 after commirt이 보장되게 수정하였습니다. 커밋 : [e91eaf3](https://github.com/Team-Kiero/Kiero-Server/pull/221/commits/e91eaf33547700c2b74d1da16956c746525148b6)) _나중에 미션/쿠폰의 삭제/수정도 실시간성이 필요해 이벤트 방식으로 리팩터링하게 될 경우, 요것들 키 삭제도 리스너 형식으로 바꾸겠습니다!_


```
**일정 조회** 
캐싱 적용 안했을 때
1회 : 308 ms
2회 : 78 ms
3회 : 77 ms
평균 응답속도 감소율 : 약 75%

캐싱 적용했을 때 
1회 : 326 ms
2회 : 14 ms
3회 : 12 ms
평균 응답속도 감소율 : 약 96%
```

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Redis 기반 전역 캐시 도입(쿠폰·미션·일정 조회) 및 조회 결과 기본 5분 TTL 적용

* **개선**
  * 조회 로직을 캐시 경로로 위임해 응답 속도 향상 (쿠폰·미션·일정)
  * 생성·수정·삭제 시 관련 캐시 자동 무효화(트랜잭션 커밋 시점에 반영)
  * 일정 변경 시 키 패턴 기반 일괄 캐시 삭제 및 변경 이벤트 발행 추가

* **테스트**
  * 캐시 무효화 동작을 위한 목(mock) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->