### PR TITLE
[refactor] #222r: 부모 오늘의 현황의 미션 조회 시, 정렬기준 적용 및 기존 정렬 기준 리팩터링

### DIFF
--- a/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
+++ b/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
@@ -18,12 +18,12 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
     @Query("SELECT m FROM Mission m " +
            "WHERE m.child.id = :childId AND m.dueAt >= :date " +
-           "ORDER BY m.dueAt ASC, m.updatedAt DESC, m.name ASC")
+           "ORDER BY m.dueAt ASC, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
     List<Mission> findAllByChildIdAndDueAtGreaterThanEqual(@Param("childId") Long childId, @Param("date") LocalDate date);
 
     @Query("SELECT m FROM Mission m " +
            "WHERE m.parent.id = :parentId AND m.dueAt >= :date " +
-           "ORDER BY m.dueAt ASC, m.updatedAt DESC, m.name ASC")
+           "ORDER BY m.dueAt ASC, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
     List<Mission> findAllByParentIdAndDueAtGreaterThanEqual(@Param("parentId") Long parentId, @Param("date") LocalDate date);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
@@ -36,5 +36,8 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     @Query("SELECT m FROM Mission m WHERE m.id = :missionId")
     Optional<Mission> findByIdWithLockForParent(@Param("missionId") Long missionId);
 
+    @Query("SELECT m FROM Mission m " +
+           "WHERE m.child.id = :childId AND m.dueAt = :date " +
+           "ORDER BY COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
     List<Mission> findAllByChildIdAndDueAt(Long childId, LocalDate date);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #222 

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
부모의 오늘의 현황조회 시, 기존에 기획 의도 상 정렬 기준을 적용하지 않고 있었어서 새롭게 적용하였습니다.
기존 아이, 부모의 '미션 탭 조회' 시에도, updatedAt이 null일 때 의도대로 동작하지 않는 경우를 확인하여 order by를 수정하였습니다.
이제 
1순위 : 마감일 오름차순
2순위 : updatedAt이 notnull이면 updatedAt 기준 내림차순, null이면 createdAt 기준 내림차순
3순위 : 이름 오름차순 (가나다순)
으로 정렬되어 반환됩니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="848" height="696" alt="image" src="https://github.com/user-attachments/assets/c20ace2e-41d5-4188-8ceb-86c49027a483" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 미션 정렬 기준을 개선하여 업데이트 정보가 없는 경우에도 올바른 순서로 표시됩니다.

* **새로운 기능**
  * 특정 마감일의 미션을 필터링할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->