### PR TITLE
[refactor] #226 - mission의 updatedAt 필드 수정, 미션 탭 조회 시 완료한 미션은 최하단에 위치하도록 수정

### DIFF
--- a/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
+++ b/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
@@ -18,12 +18,12 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
     @Query("SELECT m FROM Mission m " +
            "WHERE m.child.id = :childId AND m.dueAt >= :date " +
-           "ORDER BY m.dueAt ASC, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
+           "ORDER BY m.isCompleted ASC, m.dueAt ASC, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
     List<Mission> findAllByChildIdAndDueAtGreaterThanEqual(@Param("childId") Long childId, @Param("date") LocalDate date);
 
     @Query("SELECT m FROM Mission m " +
            "WHERE m.parent.id = :parentId AND m.dueAt >= :date " +
-           "ORDER BY m.dueAt ASC, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
+           "ORDER BY m.isCompleted ASC, m.dueAt ASC, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
     List<Mission> findAllByParentIdAndDueAtGreaterThanEqual(@Param("parentId") Long parentId, @Param("date") LocalDate date);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/kiero/mission/domain/Mission.java
+++ b/src/main/java/com/kiero/mission/domain/Mission.java
@@ -3,8 +3,6 @@ package com.kiero.mission.domain;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import org.springframework.data.annotation.LastModifiedDate;
-
 import com.kiero.child.domain.Child;
 import com.kiero.global.entity.BaseTimeEntity;
 import com.kiero.parent.domain.Parent;
@@ -49,7 +47,6 @@ public class Mission extends BaseTimeEntity {
 	@Column(name = MissionTableConstants.COLUMN_IS_COMPLETED, nullable = false)
 	private boolean isCompleted;
 
-	@LastModifiedDate
 	@Column(name = MissionTableConstants.COLUMN_UPDATED_AT)
 	private LocalDateTime updatedAt;
 
@@ -80,5 +77,6 @@ public class Mission extends BaseTimeEntity {
 		this.name = name;
 		this.reward = reward;
 		this.dueAt = dueAt;
+		this.updatedAt = LocalDateTime.now();
 	}
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #226

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
기존에 mission의 updatedAt에 @LastModified가 붙어, 아이가 미션을 완료했을 때도 updatedAt이 갱신되어 의도대로 정렬되지 않는 경우가 발생하였습니다. 

@LastModified를 제거하고 update() 내부에 updatedAt을 갱신하게 함으로써, '부모의 수정'이 있을 때만 반영되도록 수정하였습니다. 

3월 29일 안드 QA에서 언급되었던 '완료한 미션은 하단에 정렬되도록'이라는 기획 의도를 반영하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="862" height="732" alt="image" src="https://github.com/user-attachments/assets/3cf22763-80ac-42d1-8f44-b78b04544cff" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **정렬 순서 개선**
  * 미션 목록이 완료 상태 기준으로 먼저 정렬되고, 그 다음 마감일 순서로 표시됩니다.

* **버그 수정**
  * 미션 수정 시 업데이트 시간이 더 정확하게 기록됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->