### PR TITLE
[feat] #228 - 어드민 페이지 운영을 위한 API 추가

### DIFF
--- a/src/main/java/com/kiero/admin/adapter/in/web/AdminAuthController.java
+++ b/src/main/java/com/kiero/admin/adapter/in/web/AdminAuthController.java
@@ -1,0 +1,34 @@
+package com.kiero.admin.adapter.in.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kiero.admin.application.dto.AdminLoginRequest;
+import com.kiero.admin.application.dto.AdminLoginResponse;
+import com.kiero.admin.application.exception.AdminSuccessCode;
+import com.kiero.admin.application.port.in.AdminLoginUseCase;
+import com.kiero.global.response.dto.SuccessResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+public class AdminAuthController {
+
+	private final AdminLoginUseCase adminLoginUseCase;
+
+	@PostMapping("/login")
+	public ResponseEntity<SuccessResponse<AdminLoginResponse>> login(
+		@Valid @RequestBody AdminLoginRequest request
+	) {
+		AdminLoginResponse response = adminLoginUseCase.login(request);
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(AdminSuccessCode.LOGIN_SUCCESS, response));
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/in/web/AdminController.java
+++ b/src/main/java/com/kiero/admin/adapter/in/web/AdminController.java
@@ -1,0 +1,174 @@
+package com.kiero.admin.adapter.in.web;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kiero.admin.application.dto.AdminChildDetailResponse;
+import com.kiero.admin.application.dto.AdminChildSummaryResponse;
+import com.kiero.admin.application.dto.AdminCouponResponse;
+import com.kiero.admin.application.dto.AdminCouponUpdateRequest;
+import com.kiero.admin.application.dto.AdminMissionResponse;
+import com.kiero.admin.application.dto.AdminMissionUpdateRequest;
+import com.kiero.admin.application.dto.AdminPageResponse;
+import com.kiero.admin.application.dto.AdminParentDetailResponse;
+import com.kiero.admin.application.dto.AdminParentSummaryResponse;
+import com.kiero.admin.application.dto.AdminScheduleResponse;
+import com.kiero.admin.application.exception.AdminSuccessCode;
+import com.kiero.admin.application.port.in.AdminCouponUseCase;
+import com.kiero.admin.application.port.in.AdminMissionUseCase;
+import com.kiero.admin.application.port.in.AdminScheduleUseCase;
+import com.kiero.admin.application.port.in.AdminUserCommandUseCase;
+import com.kiero.admin.application.port.in.AdminUserQueryUseCase;
+import com.kiero.global.response.dto.SuccessResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin")
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminController {
+
+	private final AdminUserQueryUseCase adminUserQueryUseCase;
+	private final AdminUserCommandUseCase adminUserCommandUseCase;
+	private final AdminMissionUseCase adminMissionUseCase;
+	private final AdminScheduleUseCase adminScheduleUseCase;
+	private final AdminCouponUseCase adminCouponUseCase;
+
+	// ==================== 부모 관리 ====================
+
+	@GetMapping("/parents")
+	public ResponseEntity<SuccessResponse<AdminPageResponse<AdminParentSummaryResponse>>> getParents(
+		@PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+	) {
+		AdminPageResponse<AdminParentSummaryResponse> response = adminUserQueryUseCase.findAllParents(pageable);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.GET_PARENTS_SUCCESS, response));
+	}
+
+	@GetMapping("/parents/{parentId}")
+	public ResponseEntity<SuccessResponse<AdminParentDetailResponse>> getParent(
+		@PathVariable Long parentId
+	) {
+		AdminParentDetailResponse response = adminUserQueryUseCase.findParent(parentId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.GET_PARENT_SUCCESS, response));
+	}
+
+	@DeleteMapping("/parents/{parentId}")
+	public ResponseEntity<SuccessResponse<Void>> deleteParent(
+		@PathVariable Long parentId
+	) {
+		adminUserCommandUseCase.deleteParent(parentId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.DELETE_PARENT_SUCCESS, null));
+	}
+
+	// ==================== 아이 관리 ====================
+
+	@GetMapping("/children")
+	public ResponseEntity<SuccessResponse<AdminPageResponse<AdminChildSummaryResponse>>> getChildren(
+		@PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+	) {
+		AdminPageResponse<AdminChildSummaryResponse> response = adminUserQueryUseCase.findAllChildren(pageable);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.GET_CHILDREN_SUCCESS, response));
+	}
+
+	@GetMapping("/children/{childId}")
+	public ResponseEntity<SuccessResponse<AdminChildDetailResponse>> getChild(
+		@PathVariable Long childId
+	) {
+		AdminChildDetailResponse response = adminUserQueryUseCase.findChild(childId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.GET_CHILD_SUCCESS, response));
+	}
+
+	@DeleteMapping("/children/{childId}")
+	public ResponseEntity<SuccessResponse<Void>> deleteChild(
+		@PathVariable Long childId
+	) {
+		adminUserCommandUseCase.deleteChild(childId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.DELETE_CHILD_SUCCESS, null));
+	}
+
+	// ==================== 미션 관리 ====================
+
+	@GetMapping("/children/{childId}/missions")
+	public ResponseEntity<SuccessResponse<List<AdminMissionResponse>>> getMissions(
+		@PathVariable Long childId
+	) {
+		List<AdminMissionResponse> response = adminMissionUseCase.findAllByChildId(childId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.GET_MISSIONS_SUCCESS, response));
+	}
+
+	@PatchMapping("/missions/{missionId}")
+	public ResponseEntity<SuccessResponse<AdminMissionResponse>> updateMission(
+		@PathVariable Long missionId,
+		@Valid @RequestBody AdminMissionUpdateRequest request
+	) {
+		AdminMissionResponse response = adminMissionUseCase.updateMission(missionId, request);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.UPDATE_MISSION_SUCCESS, response));
+	}
+
+	@DeleteMapping("/missions/{missionId}")
+	public ResponseEntity<SuccessResponse<Void>> deleteMission(
+		@PathVariable Long missionId
+	) {
+		adminMissionUseCase.deleteMission(missionId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.DELETE_MISSION_SUCCESS, null));
+	}
+
+	// ==================== 일정 관리 ====================
+
+	@GetMapping("/children/{childId}/schedules")
+	public ResponseEntity<SuccessResponse<List<AdminScheduleResponse>>> getSchedules(
+		@PathVariable Long childId
+	) {
+		List<AdminScheduleResponse> response = adminScheduleUseCase.findAllByChildId(childId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.GET_SCHEDULES_SUCCESS, response));
+	}
+
+	@DeleteMapping("/schedules/{scheduleId}")
+	public ResponseEntity<SuccessResponse<Void>> deleteSchedule(
+		@PathVariable Long scheduleId
+	) {
+		adminScheduleUseCase.deleteSchedule(scheduleId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.DELETE_SCHEDULE_SUCCESS, null));
+	}
+
+	// ==================== 쿠폰 관리 ====================
+
+	@GetMapping("/children/{childId}/coupons")
+	public ResponseEntity<SuccessResponse<List<AdminCouponResponse>>> getCoupons(
+		@PathVariable Long childId
+	) {
+		List<AdminCouponResponse> response = adminCouponUseCase.findAllByChildId(childId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.GET_COUPONS_SUCCESS, response));
+	}
+
+	@PatchMapping("/coupons/{couponId}")
+	public ResponseEntity<SuccessResponse<AdminCouponResponse>> updateCoupon(
+		@PathVariable Long couponId,
+		@Valid @RequestBody AdminCouponUpdateRequest request
+	) {
+		AdminCouponResponse response = adminCouponUseCase.updateCoupon(couponId, request);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.UPDATE_COUPON_SUCCESS, response));
+	}
+
+	@DeleteMapping("/coupons/{couponId}")
+	public ResponseEntity<SuccessResponse<Void>> deleteCoupon(
+		@PathVariable Long couponId
+	) {
+		adminCouponUseCase.deleteCoupon(couponId);
+		return ResponseEntity.ok(SuccessResponse.of(AdminSuccessCode.DELETE_COUPON_SUCCESS, null));
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/out/auth/AdminAuthServiceAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/auth/AdminAuthServiceAdapter.java
@@ -1,0 +1,22 @@
+package com.kiero.admin.adapter.out.auth;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.admin.application.dto.AdminLoginResponse;
+import com.kiero.admin.application.port.out.AdminAuthGeneratePort;
+import com.kiero.admin.domain.Admin;
+import com.kiero.global.auth.jwt.application.service.AuthService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminAuthServiceAdapter implements AdminAuthGeneratePort {
+
+	private final AuthService authService;
+
+	@Override
+	public AdminLoginResponse generateLoginResponse(Admin admin) {
+		return authService.generateLoginResponse(admin);
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminChildPersistenceAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminChildPersistenceAdapter.java
@@ -1,0 +1,30 @@
+package com.kiero.admin.adapter.out.persistence;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.kiero.admin.application.port.out.AdminChildLoadPort;
+import com.kiero.child.adapter.out.persistence.ChildRepository;
+import com.kiero.child.domain.Child;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminChildPersistenceAdapter implements AdminChildLoadPort {
+
+	private final ChildRepository childRepository;
+
+	@Override
+	public Page<Child> findAll(Pageable pageable) {
+		return childRepository.findAll(pageable);
+	}
+
+	@Override
+	public Optional<Child> findById(Long childId) {
+		return childRepository.findById(childId);
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminCouponPersistenceAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminCouponPersistenceAdapter.java
@@ -1,0 +1,29 @@
+package com.kiero.admin.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.admin.application.port.out.AdminCouponLoadPort;
+import com.kiero.coupon.adapter.out.persistence.CouponRepository;
+import com.kiero.coupon.domain.Coupon;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminCouponPersistenceAdapter implements AdminCouponLoadPort {
+
+	private final CouponRepository couponRepository;
+
+	@Override
+	public List<Coupon> findAllByChildId(Long childId) {
+		return couponRepository.findAllByChildId(childId);
+	}
+
+	@Override
+	public Optional<Coupon> findById(Long couponId) {
+		return couponRepository.findById(couponId);
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminDeleteAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminDeleteAdapter.java
@@ -1,0 +1,125 @@
+package com.kiero.admin.adapter.out.persistence;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.admin.application.port.out.AdminDeletePort;
+import com.kiero.child.adapter.out.persistence.ChildRepository;
+import com.kiero.coupon.adapter.out.persistence.CouponRepository;
+import com.kiero.feed.adapter.out.persistence.FeedItemRepository;
+import com.kiero.mission.adapter.out.persistence.MissionRepository;
+import com.kiero.parent.adapter.out.persistence.ParentChildRepository;
+import com.kiero.parent.adapter.out.persistence.ParentRepository;
+import com.kiero.schedule.adapter.out.persistence.DiscardedScheduleRepository;
+import com.kiero.schedule.adapter.out.persistence.ScheduleDetailRepository;
+import com.kiero.schedule.adapter.out.persistence.ScheduleRepeatDaysRepository;
+import com.kiero.schedule.adapter.out.persistence.ScheduleRepository;
+import com.kiero.schedule.domain.Schedule;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminDeleteAdapter implements AdminDeletePort {
+
+	private final ScheduleRepository scheduleRepository;
+	private final ScheduleDetailRepository scheduleDetailRepository;
+	private final DiscardedScheduleRepository discardedScheduleRepository;
+	private final ScheduleRepeatDaysRepository scheduleRepeatDaysRepository;
+	private final MissionRepository missionRepository;
+	private final CouponRepository couponRepository;
+	private final FeedItemRepository feedItemRepository;
+	private final ParentChildRepository parentChildRepository;
+	private final ChildRepository childRepository;
+	private final ParentRepository parentRepository;
+
+	@Override
+	public void deleteAllSchedulesByChildId(Long childId) {
+		List<Schedule> schedules = scheduleRepository.findAllByChildId(childId);
+		deleteScheduleCascade(schedules);
+	}
+
+	@Override
+	public void deleteAllMissionsByChildId(Long childId) {
+		missionRepository.deleteAllByChildId(childId);
+	}
+
+	@Override
+	public void deleteAllCouponsByChildId(Long childId) {
+		couponRepository.deleteAllByChildId(childId);
+	}
+
+	@Override
+	public void deleteAllFeedItemsByChildId(Long childId) {
+		feedItemRepository.deleteAllByChildId(childId);
+	}
+
+	@Override
+	public void deleteAllParentChildRelationsByChildId(Long childId) {
+		parentChildRepository.deleteAllByChildId(childId);
+	}
+
+	@Override
+	public void deleteChild(Long childId) {
+		childRepository.deleteById(childId);
+	}
+
+	@Override
+	public void deleteAllSchedulesByParentId(Long parentId) {
+		List<Schedule> schedules = scheduleRepository.findAllByParentId(parentId);
+		deleteScheduleCascade(schedules);
+	}
+
+	@Override
+	public void deleteAllMissionsByParentId(Long parentId) {
+		missionRepository.deleteAllByParentId(parentId);
+	}
+
+	@Override
+	public void deleteAllCouponsByParentId(Long parentId) {
+		couponRepository.deleteAllByParentId(parentId);
+	}
+
+	@Override
+	public void deleteAllFeedItemsByParentId(Long parentId) {
+		feedItemRepository.deleteAllByParentId(parentId);
+	}
+
+	@Override
+	public void deleteAllParentChildRelationsByParentId(Long parentId) {
+		parentChildRepository.deleteAllByParentId(parentId);
+	}
+
+	@Override
+	public void deleteParent(Long parentId) {
+		parentRepository.deleteById(parentId);
+	}
+
+	@Override
+	public void deleteScheduleById(Long scheduleId) {
+		scheduleRepeatDaysRepository.deleteAllByScheduleId(scheduleId);
+		discardedScheduleRepository.deleteByScheduleId(scheduleId);
+		scheduleDetailRepository.deleteAllByScheduleId(scheduleId);
+		scheduleRepository.deleteById(scheduleId);
+	}
+
+	@Override
+	public void deleteMissionById(Long missionId) {
+		missionRepository.deleteById(missionId);
+	}
+
+	@Override
+	public void deleteCouponById(Long couponId) {
+		couponRepository.deleteById(couponId);
+	}
+
+	private void deleteScheduleCascade(List<Schedule> schedules) {
+		for (Schedule schedule : schedules) {
+			scheduleRepeatDaysRepository.deleteAllByScheduleId(schedule.getId());
+			discardedScheduleRepository.deleteByScheduleId(schedule.getId());
+			scheduleDetailRepository.deleteAllByScheduleId(schedule.getId());
+		}
+		scheduleRepository.deleteAllById(schedules.stream().map(Schedule::getId).toList());
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminMissionPersistenceAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminMissionPersistenceAdapter.java
@@ -1,0 +1,29 @@
+package com.kiero.admin.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.admin.application.port.out.AdminMissionLoadPort;
+import com.kiero.mission.adapter.out.persistence.MissionRepository;
+import com.kiero.mission.domain.Mission;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminMissionPersistenceAdapter implements AdminMissionLoadPort {
+
+	private final MissionRepository missionRepository;
+
+	@Override
+	public List<Mission> findAllByChildId(Long childId) {
+		return missionRepository.findAllByChildId(childId);
+	}
+
+	@Override
+	public Optional<Mission> findById(Long missionId) {
+		return missionRepository.findById(missionId);
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminParentPersistenceAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminParentPersistenceAdapter.java
@@ -1,0 +1,30 @@
+package com.kiero.admin.adapter.out.persistence;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.kiero.admin.application.port.out.AdminParentLoadPort;
+import com.kiero.parent.adapter.out.persistence.ParentRepository;
+import com.kiero.parent.domain.Parent;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminParentPersistenceAdapter implements AdminParentLoadPort {
+
+	private final ParentRepository parentRepository;
+
+	@Override
+	public Page<Parent> findAll(Pageable pageable) {
+		return parentRepository.findAll(pageable);
+	}
+
+	@Override
+	public Optional<Parent> findById(Long parentId) {
+		return parentRepository.findById(parentId);
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminPersistenceAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminPersistenceAdapter.java
@@ -1,0 +1,22 @@
+package com.kiero.admin.adapter.out.persistence;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.admin.application.port.out.AdminLoadPort;
+import com.kiero.admin.domain.Admin;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminPersistenceAdapter implements AdminLoadPort {
+
+	private final AdminRepository adminRepository;
+
+	@Override
+	public Optional<Admin> findByLoginId(String loginId) {
+		return adminRepository.findByLoginId(loginId);
+	}
+}

--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminRepository.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminRepository.java
@@ -1,0 +1,13 @@
+package com.kiero.admin.adapter.out.persistence;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.kiero.admin.domain.Admin;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+	Optional<Admin> findByLoginId(String loginId);
+}

--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminSchedulePersistenceAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminSchedulePersistenceAdapter.java
@@ -1,0 +1,29 @@
+package com.kiero.admin.adapter.out.persistence;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.admin.application.port.out.AdminScheduleLoadPort;
+import com.kiero.schedule.adapter.out.persistence.ScheduleRepository;
+import com.kiero.schedule.domain.Schedule;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AdminSchedulePersistenceAdapter implements AdminScheduleLoadPort {
+
+	private final ScheduleRepository scheduleRepository;
+
+	@Override
+	public List<Schedule> findAllByChildId(Long childId) {
+		return scheduleRepository.findAllByChildId(childId);
+	}
+
+	@Override
+	public Optional<Schedule> findById(Long scheduleId) {
+		return scheduleRepository.findById(scheduleId);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminChildDetailResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminChildDetailResponse.java
@@ -1,0 +1,27 @@
+package com.kiero.admin.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.kiero.child.domain.Child;
+
+public record AdminChildDetailResponse(
+	Long id,
+	String lastName,
+	String firstName,
+	int coinAmount,
+	LocalDateTime createdAt,
+	List<AdminParentSummaryResponse> parents
+) {
+
+	public static AdminChildDetailResponse of(Child child, List<AdminParentSummaryResponse> parents) {
+		return new AdminChildDetailResponse(
+			child.getId(),
+			child.getLastName(),
+			child.getFirstName(),
+			child.getCoinAmount(),
+			child.getCreatedAt(),
+			parents
+		);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminChildSummaryResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminChildSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.kiero.admin.application.dto;
+
+import java.time.LocalDateTime;
+
+import com.kiero.child.domain.Child;
+
+public record AdminChildSummaryResponse(
+	Long id,
+	String lastName,
+	String firstName,
+	int coinAmount,
+	LocalDateTime createdAt
+) {
+
+	public static AdminChildSummaryResponse from(Child child) {
+		return new AdminChildSummaryResponse(
+			child.getId(),
+			child.getLastName(),
+			child.getFirstName(),
+			child.getCoinAmount(),
+			child.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminCouponResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminCouponResponse.java
@@ -1,0 +1,26 @@
+package com.kiero.admin.application.dto;
+
+import java.time.LocalDateTime;
+
+import com.kiero.coupon.domain.Coupon;
+
+public record AdminCouponResponse(
+	Long id,
+	String name,
+	int price,
+	Long parentId,
+	Long childId,
+	LocalDateTime createdAt
+) {
+
+	public static AdminCouponResponse from(Coupon coupon) {
+		return new AdminCouponResponse(
+			coupon.getId(),
+			coupon.getName(),
+			coupon.getPrice(),
+			coupon.getParent().getId(),
+			coupon.getChild().getId(),
+			coupon.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminCouponUpdateRequest.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminCouponUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.kiero.admin.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record AdminCouponUpdateRequest(
+	@NotBlank(message = "쿠폰 이름은 필수입니다.")
+	String name,
+
+	@Positive(message = "쿠폰 가격은 양수여야 합니다.")
+	int price
+) {
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminLoginRequest.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminLoginRequest.java
@@ -1,0 +1,12 @@
+package com.kiero.admin.application.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminLoginRequest(
+	@NotBlank(message = "아이디는 필수입니다.")
+	String loginId,
+
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	String password
+) {
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminLoginResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminLoginResponse.java
@@ -1,0 +1,11 @@
+package com.kiero.admin.application.dto;
+
+public record AdminLoginResponse(
+	String accessToken,
+	String refreshToken
+) {
+
+	public static AdminLoginResponse of(String accessToken, String refreshToken) {
+		return new AdminLoginResponse(accessToken, refreshToken);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminMissionResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminMissionResponse.java
@@ -1,0 +1,31 @@
+package com.kiero.admin.application.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.kiero.mission.domain.Mission;
+
+public record AdminMissionResponse(
+	Long id,
+	String name,
+	int reward,
+	LocalDate dueAt,
+	boolean isCompleted,
+	Long parentId,
+	Long childId,
+	LocalDateTime createdAt
+) {
+
+	public static AdminMissionResponse from(Mission mission) {
+		return new AdminMissionResponse(
+			mission.getId(),
+			mission.getName(),
+			mission.getReward(),
+			mission.getDueAt(),
+			mission.isCompleted(),
+			mission.getParent().getId(),
+			mission.getChild().getId(),
+			mission.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminMissionUpdateRequest.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminMissionUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.kiero.admin.application.dto;
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record AdminMissionUpdateRequest(
+	@NotBlank(message = "미션 이름은 필수입니다.")
+	String name,
+
+	@Positive(message = "보상 코인은 양수여야 합니다.")
+	int reward,
+
+	@NotNull(message = "마감일은 필수입니다.")
+	LocalDate dueAt
+) {
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminPageResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminPageResponse.java
@@ -1,0 +1,24 @@
+package com.kiero.admin.application.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+public record AdminPageResponse<T>(
+	List<T> content,
+	long totalElements,
+	int totalPages,
+	int currentPage,
+	int size
+) {
+
+	public static <T> AdminPageResponse<T> from(Page<T> page) {
+		return new AdminPageResponse<>(
+			page.getContent(),
+			page.getTotalElements(),
+			page.getTotalPages(),
+			page.getNumber(),
+			page.getSize()
+		);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminParentDetailResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminParentDetailResponse.java
@@ -1,0 +1,29 @@
+package com.kiero.admin.application.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.kiero.parent.domain.Parent;
+
+public record AdminParentDetailResponse(
+	Long id,
+	String name,
+	String email,
+	String image,
+	String provider,
+	LocalDateTime createdAt,
+	List<AdminChildSummaryResponse> children
+) {
+
+	public static AdminParentDetailResponse of(Parent parent, List<AdminChildSummaryResponse> children) {
+		return new AdminParentDetailResponse(
+			parent.getId(),
+			parent.getName(),
+			parent.getEmail(),
+			parent.getImage(),
+			parent.getProvider().name(),
+			parent.getCreatedAt(),
+			children
+		);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminParentSummaryResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminParentSummaryResponse.java
@@ -1,0 +1,26 @@
+package com.kiero.admin.application.dto;
+
+import java.time.LocalDateTime;
+
+import com.kiero.parent.domain.Parent;
+
+public record AdminParentSummaryResponse(
+	Long id,
+	String name,
+	String email,
+	String image,
+	String provider,
+	LocalDateTime createdAt
+) {
+
+	public static AdminParentSummaryResponse from(Parent parent) {
+		return new AdminParentSummaryResponse(
+			parent.getId(),
+			parent.getName(),
+			parent.getEmail(),
+			parent.getImage(),
+			parent.getProvider().name(),
+			parent.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/dto/AdminScheduleResponse.java
+++ b/src/main/java/com/kiero/admin/application/dto/AdminScheduleResponse.java
@@ -1,0 +1,38 @@
+package com.kiero.admin.application.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import com.kiero.schedule.domain.Schedule;
+
+public record AdminScheduleResponse(
+	Long id,
+	String name,
+	LocalTime startTime,
+	LocalTime endTime,
+	String scheduleColor,
+	boolean isRecurring,
+	LocalDate repeatStartDate,
+	LocalDate repeatEndDate,
+	Long parentId,
+	Long childId,
+	LocalDateTime createdAt
+) {
+
+	public static AdminScheduleResponse from(Schedule schedule) {
+		return new AdminScheduleResponse(
+			schedule.getId(),
+			schedule.getName(),
+			schedule.getStartTime(),
+			schedule.getEndTime(),
+			schedule.getScheduleColor().name(),
+			schedule.isRecurring(),
+			schedule.getRepeatStartDate(),
+			schedule.getRepeatEndDate(),
+			schedule.getParent().getId(),
+			schedule.getChild().getId(),
+			schedule.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/exception/AdminErrorCode.java
+++ b/src/main/java/com/kiero/admin/application/exception/AdminErrorCode.java
@@ -20,6 +20,11 @@ public enum AdminErrorCode implements BaseCode {
 	404 NOT FOUND
 	 */
 	ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자 정보를 찾을 수 없습니다."),
+	PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 정보를 찾을 수 없습니다."),
+	CHILD_NOT_FOUND(HttpStatus.NOT_FOUND, "아이 정보를 찾을 수 없습니다."),
+	MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "미션 정보를 찾을 수 없습니다."),
+	SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일정 정보를 찾을 수 없습니다."),
+	COUPON_NOT_FOUND(HttpStatus.NOT_FOUND, "쿠폰 정보를 찾을 수 없습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/kiero/admin/application/exception/AdminErrorCode.java
+++ b/src/main/java/com/kiero/admin/application/exception/AdminErrorCode.java
@@ -1,0 +1,27 @@
+package com.kiero.admin.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.kiero.global.response.base.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminErrorCode implements BaseCode {
+
+	/*
+	401 UNAUTHORIZED
+	 */
+	INVALID_ADMIN_CREDENTIALS(HttpStatus.UNAUTHORIZED, "아이디 또는 비밀번호가 올바르지 않습니다."),
+
+	/*
+	404 NOT FOUND
+	 */
+	ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "관리자 정보를 찾을 수 없습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/kiero/admin/application/exception/AdminSuccessCode.java
+++ b/src/main/java/com/kiero/admin/application/exception/AdminSuccessCode.java
@@ -1,0 +1,22 @@
+package com.kiero.admin.application.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.kiero.global.response.base.BaseCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminSuccessCode implements BaseCode {
+
+	/*
+	200 OK
+	 */
+	LOGIN_SUCCESS(HttpStatus.OK, "관리자 로그인에 성공하였습니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/com/kiero/admin/application/exception/AdminSuccessCode.java
+++ b/src/main/java/com/kiero/admin/application/exception/AdminSuccessCode.java
@@ -15,6 +15,20 @@ public enum AdminSuccessCode implements BaseCode {
 	200 OK
 	 */
 	LOGIN_SUCCESS(HttpStatus.OK, "관리자 로그인에 성공하였습니다."),
+	GET_PARENTS_SUCCESS(HttpStatus.OK, "부모 목록 조회에 성공하였습니다."),
+	GET_PARENT_SUCCESS(HttpStatus.OK, "부모 상세 조회에 성공하였습니다."),
+	DELETE_PARENT_SUCCESS(HttpStatus.OK, "부모 삭제에 성공하였습니다."),
+	GET_CHILDREN_SUCCESS(HttpStatus.OK, "아이 목록 조회에 성공하였습니다."),
+	GET_CHILD_SUCCESS(HttpStatus.OK, "아이 상세 조회에 성공하였습니다."),
+	DELETE_CHILD_SUCCESS(HttpStatus.OK, "아이 삭제에 성공하였습니다."),
+	GET_MISSIONS_SUCCESS(HttpStatus.OK, "미션 목록 조회에 성공하였습니다."),
+	UPDATE_MISSION_SUCCESS(HttpStatus.OK, "미션 수정에 성공하였습니다."),
+	DELETE_MISSION_SUCCESS(HttpStatus.OK, "미션 삭제에 성공하였습니다."),
+	GET_SCHEDULES_SUCCESS(HttpStatus.OK, "일정 목록 조회에 성공하였습니다."),
+	DELETE_SCHEDULE_SUCCESS(HttpStatus.OK, "일정 삭제에 성공하였습니다."),
+	GET_COUPONS_SUCCESS(HttpStatus.OK, "쿠폰 목록 조회에 성공하였습니다."),
+	UPDATE_COUPON_SUCCESS(HttpStatus.OK, "쿠폰 수정에 성공하였습니다."),
+	DELETE_COUPON_SUCCESS(HttpStatus.OK, "쿠폰 삭제에 성공하였습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/kiero/admin/application/port/in/AdminCouponUseCase.java
+++ b/src/main/java/com/kiero/admin/application/port/in/AdminCouponUseCase.java
@@ -1,0 +1,12 @@
+package com.kiero.admin.application.port.in;
+
+import java.util.List;
+
+import com.kiero.admin.application.dto.AdminCouponResponse;
+import com.kiero.admin.application.dto.AdminCouponUpdateRequest;
+
+public interface AdminCouponUseCase {
+	List<AdminCouponResponse> findAllByChildId(Long childId);
+	AdminCouponResponse updateCoupon(Long couponId, AdminCouponUpdateRequest request);
+	void deleteCoupon(Long couponId);
+}

--- a/src/main/java/com/kiero/admin/application/port/in/AdminLoginUseCase.java
+++ b/src/main/java/com/kiero/admin/application/port/in/AdminLoginUseCase.java
@@ -1,0 +1,8 @@
+package com.kiero.admin.application.port.in;
+
+import com.kiero.admin.application.dto.AdminLoginRequest;
+import com.kiero.admin.application.dto.AdminLoginResponse;
+
+public interface AdminLoginUseCase {
+	AdminLoginResponse login(AdminLoginRequest request);
+}

--- a/src/main/java/com/kiero/admin/application/port/in/AdminMissionUseCase.java
+++ b/src/main/java/com/kiero/admin/application/port/in/AdminMissionUseCase.java
@@ -1,0 +1,12 @@
+package com.kiero.admin.application.port.in;
+
+import java.util.List;
+
+import com.kiero.admin.application.dto.AdminMissionResponse;
+import com.kiero.admin.application.dto.AdminMissionUpdateRequest;
+
+public interface AdminMissionUseCase {
+	List<AdminMissionResponse> findAllByChildId(Long childId);
+	AdminMissionResponse updateMission(Long missionId, AdminMissionUpdateRequest request);
+	void deleteMission(Long missionId);
+}

--- a/src/main/java/com/kiero/admin/application/port/in/AdminScheduleUseCase.java
+++ b/src/main/java/com/kiero/admin/application/port/in/AdminScheduleUseCase.java
@@ -1,0 +1,10 @@
+package com.kiero.admin.application.port.in;
+
+import java.util.List;
+
+import com.kiero.admin.application.dto.AdminScheduleResponse;
+
+public interface AdminScheduleUseCase {
+	List<AdminScheduleResponse> findAllByChildId(Long childId);
+	void deleteSchedule(Long scheduleId);
+}

--- a/src/main/java/com/kiero/admin/application/port/in/AdminUserCommandUseCase.java
+++ b/src/main/java/com/kiero/admin/application/port/in/AdminUserCommandUseCase.java
@@ -1,0 +1,6 @@
+package com.kiero.admin.application.port.in;
+
+public interface AdminUserCommandUseCase {
+	void deleteParent(Long parentId);
+	void deleteChild(Long childId);
+}

--- a/src/main/java/com/kiero/admin/application/port/in/AdminUserQueryUseCase.java
+++ b/src/main/java/com/kiero/admin/application/port/in/AdminUserQueryUseCase.java
@@ -1,0 +1,16 @@
+package com.kiero.admin.application.port.in;
+
+import org.springframework.data.domain.Pageable;
+
+import com.kiero.admin.application.dto.AdminChildDetailResponse;
+import com.kiero.admin.application.dto.AdminChildSummaryResponse;
+import com.kiero.admin.application.dto.AdminPageResponse;
+import com.kiero.admin.application.dto.AdminParentDetailResponse;
+import com.kiero.admin.application.dto.AdminParentSummaryResponse;
+
+public interface AdminUserQueryUseCase {
+	AdminPageResponse<AdminParentSummaryResponse> findAllParents(Pageable pageable);
+	AdminParentDetailResponse findParent(Long parentId);
+	AdminPageResponse<AdminChildSummaryResponse> findAllChildren(Pageable pageable);
+	AdminChildDetailResponse findChild(Long childId);
+}

--- a/src/main/java/com/kiero/admin/application/port/out/AdminAuthGeneratePort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminAuthGeneratePort.java
@@ -1,0 +1,8 @@
+package com.kiero.admin.application.port.out;
+
+import com.kiero.admin.application.dto.AdminLoginResponse;
+import com.kiero.admin.domain.Admin;
+
+public interface AdminAuthGeneratePort {
+	AdminLoginResponse generateLoginResponse(Admin admin);
+}

--- a/src/main/java/com/kiero/admin/application/port/out/AdminChildLoadPort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminChildLoadPort.java
@@ -1,0 +1,13 @@
+package com.kiero.admin.application.port.out;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kiero.child.domain.Child;
+
+public interface AdminChildLoadPort {
+	Page<Child> findAll(Pageable pageable);
+	Optional<Child> findById(Long childId);
+}

--- a/src/main/java/com/kiero/admin/application/port/out/AdminCouponLoadPort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminCouponLoadPort.java
@@ -1,0 +1,11 @@
+package com.kiero.admin.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.kiero.coupon.domain.Coupon;
+
+public interface AdminCouponLoadPort {
+	List<Coupon> findAllByChildId(Long childId);
+	Optional<Coupon> findById(Long couponId);
+}

--- a/src/main/java/com/kiero/admin/application/port/out/AdminDeletePort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminDeletePort.java
@@ -1,0 +1,25 @@
+package com.kiero.admin.application.port.out;
+
+public interface AdminDeletePort {
+
+	// 아이 삭제 시 연관 데이터 cascade 삭제
+	void deleteAllSchedulesByChildId(Long childId);
+	void deleteAllMissionsByChildId(Long childId);
+	void deleteAllCouponsByChildId(Long childId);
+	void deleteAllFeedItemsByChildId(Long childId);
+	void deleteAllParentChildRelationsByChildId(Long childId);
+	void deleteChild(Long childId);
+
+	// 부모 삭제 시 연관 데이터 cascade 삭제
+	void deleteAllSchedulesByParentId(Long parentId);
+	void deleteAllMissionsByParentId(Long parentId);
+	void deleteAllCouponsByParentId(Long parentId);
+	void deleteAllFeedItemsByParentId(Long parentId);
+	void deleteAllParentChildRelationsByParentId(Long parentId);
+	void deleteParent(Long parentId);
+
+	// 단건 삭제
+	void deleteScheduleById(Long scheduleId);
+	void deleteMissionById(Long missionId);
+	void deleteCouponById(Long couponId);
+}

--- a/src/main/java/com/kiero/admin/application/port/out/AdminLoadPort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminLoadPort.java
@@ -1,0 +1,9 @@
+package com.kiero.admin.application.port.out;
+
+import java.util.Optional;
+
+import com.kiero.admin.domain.Admin;
+
+public interface AdminLoadPort {
+	Optional<Admin> findByLoginId(String loginId);
+}

--- a/src/main/java/com/kiero/admin/application/port/out/AdminMissionLoadPort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminMissionLoadPort.java
@@ -1,0 +1,11 @@
+package com.kiero.admin.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.kiero.mission.domain.Mission;
+
+public interface AdminMissionLoadPort {
+	List<Mission> findAllByChildId(Long childId);
+	Optional<Mission> findById(Long missionId);
+}

--- a/src/main/java/com/kiero/admin/application/port/out/AdminParentLoadPort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminParentLoadPort.java
@@ -1,0 +1,13 @@
+package com.kiero.admin.application.port.out;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.kiero.parent.domain.Parent;
+
+public interface AdminParentLoadPort {
+	Page<Parent> findAll(Pageable pageable);
+	Optional<Parent> findById(Long parentId);
+}

--- a/src/main/java/com/kiero/admin/application/port/out/AdminScheduleLoadPort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminScheduleLoadPort.java
@@ -1,0 +1,11 @@
+package com.kiero.admin.application.port.out;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.kiero.schedule.domain.Schedule;
+
+public interface AdminScheduleLoadPort {
+	List<Schedule> findAllByChildId(Long childId);
+	Optional<Schedule> findById(Long scheduleId);
+}

--- a/src/main/java/com/kiero/admin/application/service/AdminCouponService.java
+++ b/src/main/java/com/kiero/admin/application/service/AdminCouponService.java
@@ -1,0 +1,54 @@
+package com.kiero.admin.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.admin.application.dto.AdminCouponResponse;
+import com.kiero.admin.application.dto.AdminCouponUpdateRequest;
+import com.kiero.admin.application.exception.AdminErrorCode;
+import com.kiero.admin.application.port.in.AdminCouponUseCase;
+import com.kiero.admin.application.port.out.AdminCouponLoadPort;
+import com.kiero.admin.application.port.out.AdminDeletePort;
+import com.kiero.coupon.domain.Coupon;
+import com.kiero.global.exception.KieroException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminCouponService implements AdminCouponUseCase {
+
+	private final AdminCouponLoadPort adminCouponLoadPort;
+	private final AdminDeletePort adminDeletePort;
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<AdminCouponResponse> findAllByChildId(Long childId) {
+		return adminCouponLoadPort.findAllByChildId(childId)
+			.stream()
+			.map(AdminCouponResponse::from)
+			.toList();
+	}
+
+	@Override
+	@Transactional
+	public AdminCouponResponse updateCoupon(Long couponId, AdminCouponUpdateRequest request) {
+		Coupon coupon = adminCouponLoadPort.findById(couponId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.COUPON_NOT_FOUND));
+
+		coupon.update(request.name(), request.price());
+
+		return AdminCouponResponse.from(coupon);
+	}
+
+	@Override
+	@Transactional
+	public void deleteCoupon(Long couponId) {
+		adminCouponLoadPort.findById(couponId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.COUPON_NOT_FOUND));
+
+		adminDeletePort.deleteCouponById(couponId);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/service/AdminLoginService.java
+++ b/src/main/java/com/kiero/admin/application/service/AdminLoginService.java
@@ -1,0 +1,38 @@
+package com.kiero.admin.application.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.admin.application.dto.AdminLoginRequest;
+import com.kiero.admin.application.dto.AdminLoginResponse;
+import com.kiero.admin.application.exception.AdminErrorCode;
+import com.kiero.admin.application.port.in.AdminLoginUseCase;
+import com.kiero.admin.application.port.out.AdminAuthGeneratePort;
+import com.kiero.admin.application.port.out.AdminLoadPort;
+import com.kiero.admin.domain.Admin;
+import com.kiero.global.exception.KieroException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminLoginService implements AdminLoginUseCase {
+
+	private final AdminLoadPort adminLoadPort;
+	private final AdminAuthGeneratePort adminAuthGeneratePort;
+	private final PasswordEncoder passwordEncoder;
+
+	@Override
+	@Transactional(readOnly = true)
+	public AdminLoginResponse login(AdminLoginRequest request) {
+		Admin admin = adminLoadPort.findByLoginId(request.loginId())
+			.orElseThrow(() -> new KieroException(AdminErrorCode.INVALID_ADMIN_CREDENTIALS));
+
+		if (!passwordEncoder.matches(request.password(), admin.getPassword())) {
+			throw new KieroException(AdminErrorCode.INVALID_ADMIN_CREDENTIALS);
+		}
+
+		return adminAuthGeneratePort.generateLoginResponse(admin);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/service/AdminMissionService.java
+++ b/src/main/java/com/kiero/admin/application/service/AdminMissionService.java
@@ -1,0 +1,54 @@
+package com.kiero.admin.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.admin.application.dto.AdminMissionResponse;
+import com.kiero.admin.application.dto.AdminMissionUpdateRequest;
+import com.kiero.admin.application.exception.AdminErrorCode;
+import com.kiero.admin.application.port.in.AdminMissionUseCase;
+import com.kiero.admin.application.port.out.AdminDeletePort;
+import com.kiero.admin.application.port.out.AdminMissionLoadPort;
+import com.kiero.global.exception.KieroException;
+import com.kiero.mission.domain.Mission;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMissionService implements AdminMissionUseCase {
+
+	private final AdminMissionLoadPort adminMissionLoadPort;
+	private final AdminDeletePort adminDeletePort;
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<AdminMissionResponse> findAllByChildId(Long childId) {
+		return adminMissionLoadPort.findAllByChildId(childId)
+			.stream()
+			.map(AdminMissionResponse::from)
+			.toList();
+	}
+
+	@Override
+	@Transactional
+	public AdminMissionResponse updateMission(Long missionId, AdminMissionUpdateRequest request) {
+		Mission mission = adminMissionLoadPort.findById(missionId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.MISSION_NOT_FOUND));
+
+		mission.update(request.name(), request.reward(), request.dueAt());
+
+		return AdminMissionResponse.from(mission);
+	}
+
+	@Override
+	@Transactional
+	public void deleteMission(Long missionId) {
+		adminMissionLoadPort.findById(missionId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.MISSION_NOT_FOUND));
+
+		adminDeletePort.deleteMissionById(missionId);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/service/AdminScheduleService.java
+++ b/src/main/java/com/kiero/admin/application/service/AdminScheduleService.java
@@ -1,0 +1,41 @@
+package com.kiero.admin.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.admin.application.dto.AdminScheduleResponse;
+import com.kiero.admin.application.exception.AdminErrorCode;
+import com.kiero.admin.application.port.in.AdminScheduleUseCase;
+import com.kiero.admin.application.port.out.AdminDeletePort;
+import com.kiero.admin.application.port.out.AdminScheduleLoadPort;
+import com.kiero.global.exception.KieroException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminScheduleService implements AdminScheduleUseCase {
+
+	private final AdminScheduleLoadPort adminScheduleLoadPort;
+	private final AdminDeletePort adminDeletePort;
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<AdminScheduleResponse> findAllByChildId(Long childId) {
+		return adminScheduleLoadPort.findAllByChildId(childId)
+			.stream()
+			.map(AdminScheduleResponse::from)
+			.toList();
+	}
+
+	@Override
+	@Transactional
+	public void deleteSchedule(Long scheduleId) {
+		adminScheduleLoadPort.findById(scheduleId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.SCHEDULE_NOT_FOUND));
+
+		adminDeletePort.deleteScheduleById(scheduleId);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/service/AdminUserCommandService.java
+++ b/src/main/java/com/kiero/admin/application/service/AdminUserCommandService.java
@@ -1,0 +1,50 @@
+package com.kiero.admin.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.admin.application.exception.AdminErrorCode;
+import com.kiero.admin.application.port.in.AdminUserCommandUseCase;
+import com.kiero.admin.application.port.out.AdminChildLoadPort;
+import com.kiero.admin.application.port.out.AdminDeletePort;
+import com.kiero.admin.application.port.out.AdminParentLoadPort;
+import com.kiero.global.exception.KieroException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserCommandService implements AdminUserCommandUseCase {
+
+	private final AdminParentLoadPort adminParentLoadPort;
+	private final AdminChildLoadPort adminChildLoadPort;
+	private final AdminDeletePort adminDeletePort;
+
+	@Override
+	@Transactional
+	public void deleteParent(Long parentId) {
+		adminParentLoadPort.findById(parentId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.PARENT_NOT_FOUND));
+
+		adminDeletePort.deleteAllSchedulesByParentId(parentId);
+		adminDeletePort.deleteAllMissionsByParentId(parentId);
+		adminDeletePort.deleteAllCouponsByParentId(parentId);
+		adminDeletePort.deleteAllFeedItemsByParentId(parentId);
+		adminDeletePort.deleteAllParentChildRelationsByParentId(parentId);
+		adminDeletePort.deleteParent(parentId);
+	}
+
+	@Override
+	@Transactional
+	public void deleteChild(Long childId) {
+		adminChildLoadPort.findById(childId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.CHILD_NOT_FOUND));
+
+		adminDeletePort.deleteAllSchedulesByChildId(childId);
+		adminDeletePort.deleteAllMissionsByChildId(childId);
+		adminDeletePort.deleteAllCouponsByChildId(childId);
+		adminDeletePort.deleteAllFeedItemsByChildId(childId);
+		adminDeletePort.deleteAllParentChildRelationsByChildId(childId);
+		adminDeletePort.deleteChild(childId);
+	}
+}

--- a/src/main/java/com/kiero/admin/application/service/AdminUserQueryService.java
+++ b/src/main/java/com/kiero/admin/application/service/AdminUserQueryService.java
@@ -1,0 +1,76 @@
+package com.kiero.admin.application.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.admin.application.dto.AdminChildDetailResponse;
+import com.kiero.admin.application.dto.AdminChildSummaryResponse;
+import com.kiero.admin.application.dto.AdminPageResponse;
+import com.kiero.admin.application.dto.AdminParentDetailResponse;
+import com.kiero.admin.application.dto.AdminParentSummaryResponse;
+import com.kiero.admin.application.exception.AdminErrorCode;
+import com.kiero.admin.application.port.in.AdminUserQueryUseCase;
+import com.kiero.admin.application.port.out.AdminChildLoadPort;
+import com.kiero.admin.application.port.out.AdminParentLoadPort;
+import com.kiero.child.domain.Child;
+import com.kiero.global.exception.KieroException;
+import com.kiero.parent.application.port.out.ParentChildLoadPort;
+import com.kiero.parent.domain.Parent;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminUserQueryService implements AdminUserQueryUseCase {
+
+	private final AdminParentLoadPort adminParentLoadPort;
+	private final AdminChildLoadPort adminChildLoadPort;
+	private final ParentChildLoadPort parentChildLoadPort;
+
+	@Override
+	@Transactional(readOnly = true)
+	public AdminPageResponse<AdminParentSummaryResponse> findAllParents(Pageable pageable) {
+		return AdminPageResponse.from(
+			adminParentLoadPort.findAll(pageable).map(AdminParentSummaryResponse::from)
+		);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AdminParentDetailResponse findParent(Long parentId) {
+		Parent parent = adminParentLoadPort.findById(parentId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.PARENT_NOT_FOUND));
+
+		List<AdminChildSummaryResponse> children = parentChildLoadPort.findAllByParentId(parentId)
+			.stream()
+			.map(pc -> AdminChildSummaryResponse.from(pc.getChild()))
+			.toList();
+
+		return AdminParentDetailResponse.of(parent, children);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AdminPageResponse<AdminChildSummaryResponse> findAllChildren(Pageable pageable) {
+		return AdminPageResponse.from(
+			adminChildLoadPort.findAll(pageable).map(AdminChildSummaryResponse::from)
+		);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public AdminChildDetailResponse findChild(Long childId) {
+		Child child = adminChildLoadPort.findById(childId)
+			.orElseThrow(() -> new KieroException(AdminErrorCode.CHILD_NOT_FOUND));
+
+		List<AdminParentSummaryResponse> parents = parentChildLoadPort.findParentsByChildId(childId)
+			.stream()
+			.map(AdminParentSummaryResponse::from)
+			.toList();
+
+		return AdminChildDetailResponse.of(child, parents);
+	}
+}

--- a/src/main/java/com/kiero/admin/domain/Admin.java
+++ b/src/main/java/com/kiero/admin/domain/Admin.java
@@ -1,0 +1,35 @@
+package com.kiero.admin.domain;
+
+import com.kiero.global.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = AdminTableConstants.TABLE_ADMIN)
+public class Admin extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = AdminTableConstants.COLUMN_ID)
+	private Long id;
+
+	@Column(name = AdminTableConstants.COLUMN_LOGIN_ID, nullable = false, unique = true)
+	private String loginId;
+
+	@Column(name = AdminTableConstants.COLUMN_PASSWORD, nullable = false)
+	private String password;
+}

--- a/src/main/java/com/kiero/admin/domain/AdminTableConstants.java
+++ b/src/main/java/com/kiero/admin/domain/AdminTableConstants.java
@@ -1,0 +1,8 @@
+package com.kiero.admin.domain;
+
+public class AdminTableConstants {
+	public static final String TABLE_ADMIN = "admin";
+	public static final String COLUMN_ID = "id";
+	public static final String COLUMN_LOGIN_ID = "login_id";
+	public static final String COLUMN_PASSWORD = "password";
+}

--- a/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponRepository.java
+++ b/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponRepository.java
@@ -3,9 +3,22 @@ package com.kiero.coupon.adapter.out.persistence;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.kiero.coupon.domain.Coupon;
 
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 	List<Coupon> findAllByChildIdOrderByPriceAscUpdatedAtDesc(Long childId);
+
+	List<Coupon> findAllByChildId(Long childId);
+
+	@Modifying
+	@Query("DELETE FROM Coupon c WHERE c.child.id = :childId")
+	void deleteAllByChildId(@Param("childId") Long childId);
+
+	@Modifying
+	@Query("DELETE FROM Coupon c WHERE c.parent.id = :parentId")
+	void deleteAllByParentId(@Param("parentId") Long parentId);
 }

--- a/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemRepository.java
+++ b/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.kiero.feed.domain.FeedItem;
 
@@ -82,4 +83,12 @@ public interface FeedItemRepository extends JpaRepository<FeedItem, Long> {
 	List<FeedItem> findUnreadFeedItemByParentId(
 		@Param("parentId") Long parentId
 	);
+
+	@Modifying
+	@Query("DELETE FROM FeedItem f WHERE f.child.id = :childId")
+	void deleteAllByChildId(@Param("childId") Long childId);
+
+	@Modifying
+	@Query("DELETE FROM FeedItem f WHERE f.parent.id = :parentId")
+	void deleteAllByParentId(@Param("parentId") Long parentId);
 }

--- a/src/main/java/com/kiero/global/auth/jwt/application/service/AuthService.java
+++ b/src/main/java/com/kiero/global/auth/jwt/application/service/AuthService.java
@@ -8,6 +8,8 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kiero.admin.application.dto.AdminLoginResponse;
+import com.kiero.admin.domain.Admin;
 import com.kiero.child.application.dto.ChildLoginResponse;
 import com.kiero.child.domain.Child;
 import com.kiero.global.auth.enums.Role;
@@ -43,6 +45,16 @@ public class AuthService {
 
 		return ParentLoginResponse.of(parent.getName(), parent.getEmail(), parent.getImage(), parent.getRole(),
 			accessToken, refreshToken);
+	}
+
+	public AdminLoginResponse generateLoginResponse(Admin admin) {
+		Collection<GrantedAuthority> authorities = List.of(Role.ADMIN.toGrantedAuthority());
+		UsernamePasswordAuthenticationToken authenticationToken = createAuthenticationToken(admin.getId(), Role.ADMIN,
+			authorities);
+		String refreshToken = issueAndSaveRefreshToken(admin.getId(), authenticationToken);
+		String accessToken = jwtTokenProvider.issueAccessToken(authenticationToken);
+
+		return AdminLoginResponse.of(accessToken, refreshToken);
 	}
 
 	public ChildLoginResponse generateLoginResponse(Child child) {

--- a/src/main/java/com/kiero/global/config/SecurityConfig.java
+++ b/src/main/java/com/kiero/global/config/SecurityConfig.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -46,7 +48,8 @@ public class SecurityConfig {
 					"/api/v1/parents/login/access-token",
 					"/api/v1/children/login",
 					"/api/v1/tokens/reissue/*",
-					"/api/v1/tokens/subscribe-token"
+					"/api/v1/tokens/subscribe-token",
+					"/api/v1/admin/login"
 				).permitAll()
 
 				.requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()
@@ -56,5 +59,10 @@ public class SecurityConfig {
 			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
 	}
 }

--- a/src/main/java/com/kiero/mission/adapter/out/ai/SpringAiMissionSuggestionAdapter.java
+++ b/src/main/java/com/kiero/mission/adapter/out/ai/SpringAiMissionSuggestionAdapter.java
@@ -48,6 +48,7 @@ public class SpringAiMissionSuggestionAdapter implements MissionSuggestionAiPort
 		   5. dueAt 추출 규칙 (매우 중요 - 엄격 적용)
 		      - 원칙: 해당 미션 항목의 **본문** 또는 **같은 항목 내의 바로 앞 문장**에 날짜/요일이 명시된 경우 그 날짜를 추출한다.
 		      - ★문맥 허용: "수요일 미술시간 준비물" 처럼, 특정 행사를 위한 준비물인 경우 그 행사의 날짜를 dueAt으로 잡는다.
+		      - ★오늘 표현: "오늘까지", "오늘", "당일" 같은 표현이 본문에 명시된 경우 → 참조표에서 [오늘] 레이블이 붙은 날짜를 선택.
 		      - ★절대 금지: '오늘의 숙제', '알림장' 같은 **문서 전체의 제목/헤더**를 보고 날짜를 추측하지 말 것.
 		      - ★결과: 위 조건에 맞는 날짜 정보가 없으면, 시스템이 처리하므로 **반드시 dueAt은 null**로 반환할 것.
 
@@ -72,6 +73,9 @@ public class SpringAiMissionSuggestionAdapter implements MissionSuggestionAiPort
 		\s
 		 입력: "3. 다음주 수요일 미술시간. 준비물 붓 챙겨오기"
 		 출력: [\\\\{"name": "미술 준비물 붓 챙기기", "dueAt": "2026-01-28"\\\\}]
+		\s
+		 입력: "오늘까지 수학 익힘책을 풀어주세요."
+		 출력: [\\\\{"name": "수학익힘책 풀기", "dueAt": "{today}"\\\\}]
 		
 		   [출력 포맷]
 		   - JSON 배열만 출력 (Markdown 금지).

--- a/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
+++ b/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -40,4 +41,14 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
            "WHERE m.child.id = :childId AND m.dueAt = :date " +
            "ORDER BY COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
     List<Mission> findAllByChildIdAndDueAt(Long childId, LocalDate date);
+
+    List<Mission> findAllByChildId(Long childId);
+
+    @Modifying
+    @Query("DELETE FROM Mission m WHERE m.child.id = :childId")
+    void deleteAllByChildId(@Param("childId") Long childId);
+
+    @Modifying
+    @Query("DELETE FROM Mission m WHERE m.parent.id = :parentId")
+    void deleteAllByParentId(@Param("parentId") Long parentId);
 }

--- a/src/main/java/com/kiero/parent/adapter/out/persistence/ParentChildRepository.java
+++ b/src/main/java/com/kiero/parent/adapter/out/persistence/ParentChildRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -30,4 +31,11 @@ public interface ParentChildRepository extends JpaRepository<ParentChild, Long> 
 		""")
 	List<Parent> findParentsByChildId(@Param("childId") Long childId);
 
+	@Modifying
+	@Query("DELETE FROM ParentChild pc WHERE pc.child.id = :childId")
+	void deleteAllByChildId(@Param("childId") Long childId);
+
+	@Modifying
+	@Query("DELETE FROM ParentChild pc WHERE pc.parent.id = :parentId")
+	void deleteAllByParentId(@Param("parentId") Long parentId);
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleRepository.java
@@ -14,6 +14,8 @@ import com.kiero.schedule.domain.Schedule;
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 	List<Schedule> findAllByChildId(Long childId);
 
+	List<Schedule> findAllByParentId(Long parentId);
+
 	Optional<Schedule> findFirstByChildIdOrderByCreatedAtDesc(Long childId);
 
 	@Modifying


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #228 

## Work Description ✏️

- 어드민 로그인
- 어드민 유저 관리 (조회/수정/삭제)
- 어드민 미션 관리 (조회/수정/삭제)
- 어드민 일정 관리 (조회/삭제)
- 어드민 쿠폰 관리(조회/수정/삭제)

admin 테이블이 새로 추가되었습니다.
어드민 페이지 로그인의 경우, 따로 Oatuh를 사용하지는 않고, ID/PW 기반으로 로그인합니다.
회원가입 API는 없으며, 어드민 계정은 DB에서 직접 관리할 예정입니다.
아이 삭제 시, 미션, 쿠폰, 일정 등 모든 해당 자녀에게 종속된 데이터가 CASCADE 방식으로 삭제됩니다.

전체적으로 복잡한 기능은 없고, ADMIN 전용 RUD API들만 구축한 작업이니 가볍게 확인해주시면 될 것 같습니다!

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

추후 로그인 api에 rate limit 추가할 예정입니다

## To Reviewers 📢

지금 dev서버에 ssl 인증서가 안달려있는데, 슬슬 도메인 구매 이후 인증서 발급도 고려해보면 좋을 것 같습니당🙄

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자 로그인 인증 추가(토큰 발급)
  * 부모 관리: 목록(페이지네이션), 상세 조회, 삭제
  * 아이 관리: 목록(페이지네이션), 상세 조회, 삭제
  * 미션 관리: 목록 조회, 수정, 삭제
  * 일정 관리: 목록 조회, 삭제
  * 쿠폰 관리: 목록 조회, 수정, 삭제
  * 삭제 작업 시 관련 데이터 연쇄 삭제 지원 (부모/아이 단위)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->