### PR TITLE
[refactor] #232 - 일정 순서 계산 시 스킵된 일정은 제외하고 계산

### DIFF
--- a/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleQueryService.java
@@ -134,7 +134,11 @@ public class ScheduleQueryService implements ScheduleQueryUseCase {
 			);
 		}
 
-		int order = filteredAllScheduleDetails.indexOf(todo) + 1;
+		int order = filteredAllScheduleDetails.stream()
+			.filter(sd -> sd.getScheduleStatus() != ScheduleStatus.SKIPPED)
+			.toList()
+			.indexOf(todo) + 1;
+
 		boolean isNowScheduleVerified = todo.getScheduleStatus() == ScheduleStatus.VERIFIED;
 
 		return TodayScheduleResponse.of(


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #232

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
qa 시트로 이슈 확인하여, 일정 순서를 계산할 때 인증하지 않고 스킵된 일정(Status.SKIPPED)은 제외하고 계산하도록 수정하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="888" height="700" alt="image" src="https://github.com/user-attachments/assets/f54e325f-d100-47c4-aa6a-254c2ccca910" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 일정 항목의 순서 번호 계산이 개선되었습니다. 건너뛴 항목이 번호에 포함되지 않아 더 정확한 순서로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->