### PR TITLE
[refactor] #238 - mission 엔터티에 completedAt 추가, 미션 탭 정렬 기준 조정

### DIFF
--- a/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
+++ b/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
@@ -19,12 +19,12 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
     @Query("SELECT m FROM Mission m " +
            "WHERE m.child.id = :childId AND m.dueAt >= :date " +
-           "ORDER BY m.isCompleted ASC, m.dueAt ASC, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
+           "ORDER BY m.dueAt ASC, m.isCompleted ASC, m.completedAt DESC nulls last, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
     List<Mission> findAllByChildIdAndDueAtGreaterThanEqual(@Param("childId") Long childId, @Param("date") LocalDate date);
 
     @Query("SELECT m FROM Mission m " +
            "WHERE m.parent.id = :parentId AND m.dueAt >= :date " +
-           "ORDER BY m.isCompleted ASC, m.dueAt ASC, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
+           "ORDER BY m.dueAt ASC, m.isCompleted ASC, m.completedAt DESC nulls last, COALESCE(m.updatedAt, m.createdAt) DESC, m.name ASC")
     List<Mission> findAllByParentIdAndDueAtGreaterThanEqual(@Param("parentId") Long parentId, @Param("date") LocalDate date);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/kiero/mission/domain/Mission.java
+++ b/src/main/java/com/kiero/mission/domain/Mission.java
@@ -47,6 +47,9 @@ public class Mission extends BaseTimeEntity {
 	@Column(name = MissionTableConstants.COLUMN_IS_COMPLETED, nullable = false)
 	private boolean isCompleted;
 
+	@Column(name = MissionTableConstants.COLUMN_COMPLETED_AT, nullable = true)
+	private LocalDateTime completedAt;
+
 	@Column(name = MissionTableConstants.COLUMN_UPDATED_AT)
 	private LocalDateTime updatedAt;
 
@@ -71,6 +74,7 @@ public class Mission extends BaseTimeEntity {
 
 	public void complete() {
 		this.isCompleted = true;
+		this.completedAt = LocalDateTime.now();
 	}
 
 	public void update(String name, int reward, LocalDate dueAt) {

--- a/src/main/java/com/kiero/mission/domain/MissionTableConstants.java
+++ b/src/main/java/com/kiero/mission/domain/MissionTableConstants.java
@@ -7,6 +7,7 @@ public class MissionTableConstants {
 	public static final String COLUMN_REWARD = "reward";
 	public static final String COLUMN_DUE_AT = "due_at";
 	public static final String COLUMN_IS_COMPLETED = "is_completed";
+	public static final String COLUMN_COMPLETED_AT = "completed_at";
 	public static final String COLUMN_PARENT_ID = "parent_id";
 	public static final String COLUMN_CHILD_ID = "child_id";
 	public static final String COLUMN_UPDATED_AT = "updated_at";


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #238

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- mission 엔터티에 completedAt을 추가하였습니다. 
- 기획 요구사항에 맞춰 미션 탭 정렬 기준을 조정하였습니다.  

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
<img width="886" height="730" alt="image" src="https://github.com/user-attachments/assets/f4b09b57-53b2-4e5e-96cb-66d87e7d8f38" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
