### PR TITLE
[feat] #241 - 부모 탈퇴 api, 부모의 탈퇴 세션 조회 api 구현

### DIFF
--- a/src/main/java/com/kiero/child/adapter/in/web/ChildController.java
+++ b/src/main/java/com/kiero/child/adapter/in/web/ChildController.java
@@ -13,9 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 import com.kiero.child.application.dto.ChildLoginRequest;
 import com.kiero.child.application.dto.ChildLoginResponse;
 import com.kiero.child.application.dto.ChildMeResponse;
+import com.kiero.child.application.dto.ParentWithdrawalStatusResponse;
 import com.kiero.child.application.exception.ChildSuccessCode;
 import com.kiero.child.application.port.in.ChildLoginUseCase;
 import com.kiero.child.application.port.in.ChildQueryUseCase;
+import com.kiero.child.application.port.in.ParentWithdrawalQueryUseCase;
 import com.kiero.global.auth.annotation.CurrentMember;
 import com.kiero.global.auth.dto.CurrentAuth;
 import com.kiero.global.response.dto.SuccessResponse;
@@ -34,6 +36,7 @@ public class ChildController {
 	private static final int COOKIE_MAX_AGE = 7 * 24 * 60 * 60;
 	private final ChildLoginUseCase childLoginUseCase;
 	private final ChildQueryUseCase childQueryUseCase;
+	private final ParentWithdrawalQueryUseCase parentWithdrawalQueryUseCase;
 
 	@PostMapping("/login")
 	public ResponseEntity<SuccessResponse<ChildLoginResponse>> login(
@@ -62,5 +65,17 @@ public class ChildController {
 
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(ChildSuccessCode.GET_INFO_SUCCESS, response));
+	}
+
+	@PreAuthorize("hasAnyRole('CHILD', 'ADMIN')")
+	@GetMapping("/parent-withdrawal-status")
+	public ResponseEntity<SuccessResponse<ParentWithdrawalStatusResponse>> getParentWithdrawalStatus(
+		@CurrentMember CurrentAuth currentAuth
+	) {
+		ParentWithdrawalStatusResponse response = parentWithdrawalQueryUseCase.getParentWithdrawalStatus(
+			currentAuth.memberId());
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(ChildSuccessCode.PARENT_WITHDRAWAL_STATUS_RETRIEVED, response));
 	}
 }

--- a/src/main/java/com/kiero/child/adapter/out/persistence/ChildPersistenceAdapter.java
+++ b/src/main/java/com/kiero/child/adapter/out/persistence/ChildPersistenceAdapter.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.kiero.child.application.port.out.ChildDeletePort;
 import com.kiero.child.application.port.out.ChildLoadPort;
 import com.kiero.child.application.port.out.ChildSavePort;
 import com.kiero.child.domain.Child;
@@ -12,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class ChildPersistenceAdapter implements ChildSavePort, ChildLoadPort {
+public class ChildPersistenceAdapter implements ChildSavePort, ChildLoadPort, ChildDeletePort {
 
 	private final ChildRepository childRepository;
 
@@ -34,5 +35,10 @@ public class ChildPersistenceAdapter implements ChildSavePort, ChildLoadPort {
 	@Override
 	public Optional<Child> findByParentIdAndName(Long parentId, String lastName, String firstName) {
 		return childRepository.findByParentIdAndName(parentId, lastName, firstName);
+	}
+
+	@Override
+	public void deleteById(Long childId) {
+		childRepository.deleteById(childId);
 	}
 }

--- a/src/main/java/com/kiero/child/adapter/out/redis/ParentWithdrawCheckRedisAdapter.java
+++ b/src/main/java/com/kiero/child/adapter/out/redis/ParentWithdrawCheckRedisAdapter.java
@@ -1,0 +1,22 @@
+package com.kiero.child.adapter.out.redis;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.child.application.port.out.ParentWithdrawCheckPort;
+import com.kiero.parent.adapter.out.redis.ParentWithdrawalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ParentWithdrawCheckRedisAdapter implements ParentWithdrawCheckPort {
+
+	private static final String KEY_PREFIX = "child:";
+
+	private final ParentWithdrawalRepository parentWithdrawalRepository;
+
+	@Override
+	public boolean isParentWithdrawn(Long childId) {
+		return parentWithdrawalRepository.existsById(KEY_PREFIX + childId);
+	}
+}

--- a/src/main/java/com/kiero/child/application/dto/ParentWithdrawalStatusResponse.java
+++ b/src/main/java/com/kiero/child/application/dto/ParentWithdrawalStatusResponse.java
@@ -1,0 +1,6 @@
+package com.kiero.child.application.dto;
+
+public record ParentWithdrawalStatusResponse(
+	boolean isParentWithdrawn
+) {
+}

--- a/src/main/java/com/kiero/child/application/exception/ChildSuccessCode.java
+++ b/src/main/java/com/kiero/child/application/exception/ChildSuccessCode.java
@@ -15,6 +15,7 @@ public enum ChildSuccessCode implements BaseCode {
     */
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
     GET_INFO_SUCCESS(HttpStatus.OK, "정보 조회에 성공하였습니다."),
+    PARENT_WITHDRAWAL_STATUS_RETRIEVED(HttpStatus.OK, "부모 탈퇴 여부가 성공적으로 조회되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/kiero/child/application/port/in/ParentWithdrawalQueryUseCase.java
+++ b/src/main/java/com/kiero/child/application/port/in/ParentWithdrawalQueryUseCase.java
@@ -1,0 +1,7 @@
+package com.kiero.child.application.port.in;
+
+import com.kiero.child.application.dto.ParentWithdrawalStatusResponse;
+
+public interface ParentWithdrawalQueryUseCase {
+	ParentWithdrawalStatusResponse getParentWithdrawalStatus(Long childId);
+}

--- a/src/main/java/com/kiero/child/application/port/out/ChildDeletePort.java
+++ b/src/main/java/com/kiero/child/application/port/out/ChildDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.child.application.port.out;
+
+public interface ChildDeletePort {
+	void deleteById(Long childId);
+}

--- a/src/main/java/com/kiero/child/application/port/out/ParentWithdrawCheckPort.java
+++ b/src/main/java/com/kiero/child/application/port/out/ParentWithdrawCheckPort.java
@@ -1,0 +1,5 @@
+package com.kiero.child.application.port.out;
+
+public interface ParentWithdrawCheckPort {
+	boolean isParentWithdrawn(Long childId);
+}

--- a/src/main/java/com/kiero/child/application/service/ParentWithdrawalQueryService.java
+++ b/src/main/java/com/kiero/child/application/service/ParentWithdrawalQueryService.java
@@ -1,0 +1,21 @@
+package com.kiero.child.application.service;
+
+import org.springframework.stereotype.Service;
+
+import com.kiero.child.application.dto.ParentWithdrawalStatusResponse;
+import com.kiero.child.application.port.in.ParentWithdrawalQueryUseCase;
+import com.kiero.child.application.port.out.ParentWithdrawCheckPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ParentWithdrawalQueryService implements ParentWithdrawalQueryUseCase {
+
+	private final ParentWithdrawCheckPort parentWithdrawCheckPort;
+
+	@Override
+	public ParentWithdrawalStatusResponse getParentWithdrawalStatus(Long childId) {
+		return new ParentWithdrawalStatusResponse(parentWithdrawCheckPort.isParentWithdrawn(childId));
+	}
+}

--- a/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponPersistenceAdapter.java
+++ b/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponPersistenceAdapter.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import com.kiero.coupon.application.port.out.CouponDeletePort;
 import com.kiero.coupon.application.port.out.CouponLoadPort;
+import com.kiero.coupon.application.port.out.CouponTransferPort;
 import com.kiero.coupon.application.port.out.CouponPersistencePort;
 import com.kiero.coupon.domain.Coupon;
 
@@ -14,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class CouponPersistenceAdapter implements CouponLoadPort, CouponPersistencePort, CouponDeletePort {
+public class CouponPersistenceAdapter implements CouponLoadPort, CouponPersistencePort, CouponDeletePort, CouponTransferPort {
 
 	private final CouponRepository couponRepository;
 
@@ -41,5 +42,10 @@ public class CouponPersistenceAdapter implements CouponLoadPort, CouponPersisten
 	@Override
 	public void deleteAllByChildId(Long childId) {
 		couponRepository.deleteAllByChildId(childId);
+	}
+
+	@Override
+	public void transferOwnership(Long fromParentId, Long toParentId, Long childId) {
+		couponRepository.transferOwnershipByParentIdAndChildId(fromParentId, toParentId, childId);
 	}
 }

--- a/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponPersistenceAdapter.java
+++ b/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponPersistenceAdapter.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.kiero.coupon.application.port.out.CouponDeletePort;
 import com.kiero.coupon.application.port.out.CouponLoadPort;
 import com.kiero.coupon.application.port.out.CouponPersistencePort;
 import com.kiero.coupon.domain.Coupon;
@@ -13,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class CouponPersistenceAdapter implements CouponLoadPort, CouponPersistencePort {
+public class CouponPersistenceAdapter implements CouponLoadPort, CouponPersistencePort, CouponDeletePort {
 
 	private final CouponRepository couponRepository;
 
@@ -35,5 +36,10 @@ public class CouponPersistenceAdapter implements CouponLoadPort, CouponPersisten
 	@Override
 	public void delete(Coupon coupon) {
 		couponRepository.delete(coupon);
+	}
+
+	@Override
+	public void deleteAllByChildId(Long childId) {
+		couponRepository.deleteAllByChildId(childId);
 	}
 }

--- a/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponRepository.java
+++ b/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponRepository.java
@@ -21,4 +21,8 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 	@Modifying
 	@Query("DELETE FROM Coupon c WHERE c.parent.id = :parentId")
 	void deleteAllByParentId(@Param("parentId") Long parentId);
+
+	@Modifying
+	@Query(value = "UPDATE coupon SET parent_id = :newParentId WHERE parent_id = :oldParentId AND child_id = :childId", nativeQuery = true)
+	void transferOwnershipByParentIdAndChildId(@Param("oldParentId") Long oldParentId, @Param("newParentId") Long newParentId, @Param("childId") Long childId);
 }

--- a/src/main/java/com/kiero/coupon/application/port/out/CouponDeletePort.java
+++ b/src/main/java/com/kiero/coupon/application/port/out/CouponDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.coupon.application.port.out;
+
+public interface CouponDeletePort {
+	void deleteAllByChildId(Long childId);
+}

--- a/src/main/java/com/kiero/coupon/application/port/out/CouponTransferPort.java
+++ b/src/main/java/com/kiero/coupon/application/port/out/CouponTransferPort.java
@@ -1,0 +1,5 @@
+package com.kiero.coupon.application.port.out;
+
+public interface CouponTransferPort {
+	void transferOwnership(Long fromParentId, Long toParentId, Long childId);
+}

--- a/src/main/java/com/kiero/coupon/application/service/CouponCommandService.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCommandService.java
@@ -121,7 +121,7 @@ public class CouponCommandService implements CouponCommandUseCase {
 
     child.deductCoin(coupon.getPrice());
 
-	  List<Parent> parents = parentChildLoadPort.findParentsByChildId(child.getId());
+	  List<Parent> parents = parentChildLoadPort.findActiveParentsByChildId(child.getId());
 
     couponEventPort.publish(new CouponPurchaseEventForFeed(
 		parents,

--- a/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemPersistenceAdapter.java
+++ b/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemPersistenceAdapter.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import com.kiero.feed.application.port.out.FeedItemCommandPort;
+import com.kiero.feed.application.port.out.FeedItemTransferPort;
 import com.kiero.feed.application.port.out.FeedItemDeletePort;
 import com.kiero.feed.application.port.out.FeedItemQueryPort;
 import com.kiero.feed.domain.FeedItem;
@@ -17,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class FeedItemPersistenceAdapter implements FeedItemCommandPort, FeedItemQueryPort, FeedItemDeletePort {
+public class FeedItemPersistenceAdapter implements FeedItemCommandPort, FeedItemQueryPort, FeedItemDeletePort, FeedItemTransferPort {
 
 	private final FeedItemRepository feedItemRepository;
 
@@ -66,5 +67,10 @@ public class FeedItemPersistenceAdapter implements FeedItemCommandPort, FeedItem
 	@Override
 	public void deleteAllByChildId(Long childId) {
 		feedItemRepository.deleteAllByChildId(childId);
+	}
+
+	@Override
+	public void transferOwnership(Long fromParentId, Long toParentId, Long childId) {
+		feedItemRepository.transferOwnershipByParentIdAndChildId(fromParentId, toParentId, childId);
 	}
 }

--- a/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemPersistenceAdapter.java
+++ b/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemPersistenceAdapter.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import com.kiero.feed.application.port.out.FeedItemCommandPort;
+import com.kiero.feed.application.port.out.FeedItemDeletePort;
 import com.kiero.feed.application.port.out.FeedItemQueryPort;
 import com.kiero.feed.domain.FeedItem;
 import com.kiero.feed.domain.enums.EventType;
@@ -16,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class FeedItemPersistenceAdapter implements FeedItemCommandPort, FeedItemQueryPort {
+public class FeedItemPersistenceAdapter implements FeedItemCommandPort, FeedItemQueryPort, FeedItemDeletePort {
 
 	private final FeedItemRepository feedItemRepository;
 
@@ -60,5 +61,10 @@ public class FeedItemPersistenceAdapter implements FeedItemCommandPort, FeedItem
 	@Override
 	public List<FeedItem> findUnreadFeedItem(Long parentId) {
 		return feedItemRepository.findUnreadFeedItemByParentId(parentId);
+	}
+
+	@Override
+	public void deleteAllByChildId(Long childId) {
+		feedItemRepository.deleteAllByChildId(childId);
 	}
 }

--- a/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemRepository.java
+++ b/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemRepository.java
@@ -91,4 +91,8 @@ public interface FeedItemRepository extends JpaRepository<FeedItem, Long> {
 	@Modifying
 	@Query("DELETE FROM FeedItem f WHERE f.parent.id = :parentId")
 	void deleteAllByParentId(@Param("parentId") Long parentId);
+
+	@Modifying
+	@Query(value = "UPDATE feed_item SET parent_id = :newParentId WHERE parent_id = :oldParentId AND child_id = :childId", nativeQuery = true)
+	void transferOwnershipByParentIdAndChildId(@Param("oldParentId") Long oldParentId, @Param("newParentId") Long newParentId, @Param("childId") Long childId);
 }

--- a/src/main/java/com/kiero/feed/application/port/out/FeedItemDeletePort.java
+++ b/src/main/java/com/kiero/feed/application/port/out/FeedItemDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.feed.application.port.out;
+
+public interface FeedItemDeletePort {
+	void deleteAllByChildId(Long childId);
+}

--- a/src/main/java/com/kiero/feed/application/port/out/FeedItemTransferPort.java
+++ b/src/main/java/com/kiero/feed/application/port/out/FeedItemTransferPort.java
@@ -1,0 +1,5 @@
+package com.kiero.feed.application.port.out;
+
+public interface FeedItemTransferPort {
+	void transferOwnership(Long fromParentId, Long toParentId, Long childId);
+}

--- a/src/main/java/com/kiero/global/auth/enums/Role.java
+++ b/src/main/java/com/kiero/global/auth/enums/Role.java
@@ -12,6 +12,7 @@ public enum Role {
 	PARENT("ROLE_PARENT"),
 	CHILD("ROLE_CHILD"),
 	ADMIN("ROLE_ADMIN"),
+	WITHDRAWN("ROLE_WITHDRAWN"),
 	;
 
 	private final String roleName;

--- a/src/main/java/com/kiero/global/sse/adapter/in/event/SsePushEventListener.java
+++ b/src/main/java/com/kiero/global/sse/adapter/in/event/SsePushEventListener.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.kiero.child.application.dto.ChildJoinedEvent;
 import com.kiero.coupon.application.dto.CouponCreatedEvent;
+import com.kiero.parent.application.dto.ParentWithdrawnEvent;
 import com.kiero.feed.infrastructure.dto.FeedItemsCreatedEvent;
 import com.kiero.global.sse.application.port.in.SsePushUseCase;
 import com.kiero.global.sse.domain.SseEventType;
@@ -126,5 +127,14 @@ public class SsePushEventListener {
 			log.debug("부모 SSE 푸시 (오늘의 불 피우기 완료): parentId={}, childId={}", parentId, event.childId());
 			ssePushUseCase.pushToParent(parentId, SseEventType.FIRE_LIT, data);
 		}
+	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(ParentWithdrawnEvent event) {
+		Map<String, Object> data = new LinkedHashMap<>();
+		data.put("eventType", SseEventType.PARENT_WITHDRAWN.name());
+
+		log.debug("자녀 SSE 푸시 (부모 탈퇴): childId={}", event.childId());
+		ssePushUseCase.pushToChild(event.childId(), SseEventType.PARENT_WITHDRAWN, data);
 	}
 }

--- a/src/main/java/com/kiero/global/sse/domain/SseEventType.java
+++ b/src/main/java/com/kiero/global/sse/domain/SseEventType.java
@@ -17,6 +17,7 @@ public enum SseEventType {
 	MISSION_CREATED("mission", "미션 생성"),
 	SCHEDULE_MODIFIED("schedule", "스케줄 변경"),
 	COUPON_CREATED("coupon", "쿠폰 생성"),
+	PARENT_WITHDRAWN("parentWithdrawn", "부모 탈퇴"),
 
 	// 부모 + 자녀 이벤트
 	SCHEDULE_STATUS_UPDATED("schedule", "일정 상태 업데이트"),

--- a/src/main/java/com/kiero/mission/adapter/out/persistence/MissionPersistenceAdapter.java
+++ b/src/main/java/com/kiero/mission/adapter/out/persistence/MissionPersistenceAdapter.java
@@ -8,13 +8,14 @@ import org.springframework.stereotype.Component;
 
 import com.kiero.mission.application.port.out.MissionDeletePort;
 import com.kiero.mission.application.port.out.MissionPersistencePort;
+import com.kiero.mission.application.port.out.MissionTransferPort;
 import com.kiero.mission.domain.Mission;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class MissionPersistenceAdapter implements MissionPersistencePort, MissionDeletePort {
+public class MissionPersistenceAdapter implements MissionPersistencePort, MissionDeletePort, MissionTransferPort {
 
 	private final MissionRepository missionRepository;
 
@@ -66,6 +67,11 @@ public class MissionPersistenceAdapter implements MissionPersistencePort, Missio
 	@Override
 	public void deleteAllByChildId(Long childId) {
 		missionRepository.deleteAllByChildId(childId);
+	}
+
+	@Override
+	public void transferOwnership(Long fromParentId, Long toParentId, Long childId) {
+		missionRepository.transferOwnershipByParentIdAndChildId(fromParentId, toParentId, childId);
 	}
 
 }

--- a/src/main/java/com/kiero/mission/adapter/out/persistence/MissionPersistenceAdapter.java
+++ b/src/main/java/com/kiero/mission/adapter/out/persistence/MissionPersistenceAdapter.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
+import com.kiero.mission.application.port.out.MissionDeletePort;
 import com.kiero.mission.application.port.out.MissionPersistencePort;
 import com.kiero.mission.domain.Mission;
 
@@ -13,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class MissionPersistenceAdapter implements MissionPersistencePort {
+public class MissionPersistenceAdapter implements MissionPersistencePort, MissionDeletePort {
 
 	private final MissionRepository missionRepository;
 
@@ -60,6 +61,11 @@ public class MissionPersistenceAdapter implements MissionPersistencePort {
 	@Override
 	public List<Mission> findAllByChildIdAndDueAt(Long childId, LocalDate date) {
 		return missionRepository.findAllByChildIdAndDueAt(childId, date);
+	}
+
+	@Override
+	public void deleteAllByChildId(Long childId) {
+		missionRepository.deleteAllByChildId(childId);
 	}
 
 }

--- a/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
+++ b/src/main/java/com/kiero/mission/adapter/out/persistence/MissionRepository.java
@@ -51,4 +51,8 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     @Modifying
     @Query("DELETE FROM Mission m WHERE m.parent.id = :parentId")
     void deleteAllByParentId(@Param("parentId") Long parentId);
+
+    @Modifying
+    @Query(value = "UPDATE mission SET parent_id = :newParentId WHERE parent_id = :oldParentId AND child_id = :childId", nativeQuery = true)
+    void transferOwnershipByParentIdAndChildId(@Param("oldParentId") Long oldParentId, @Param("newParentId") Long newParentId, @Param("childId") Long childId);
 }

--- a/src/main/java/com/kiero/mission/application/port/out/MissionDeletePort.java
+++ b/src/main/java/com/kiero/mission/application/port/out/MissionDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.mission.application.port.out;
+
+public interface MissionDeletePort {
+	void deleteAllByChildId(Long childId);
+}

--- a/src/main/java/com/kiero/mission/application/port/out/MissionTransferPort.java
+++ b/src/main/java/com/kiero/mission/application/port/out/MissionTransferPort.java
@@ -1,0 +1,5 @@
+package com.kiero.mission.application.port.out;
+
+public interface MissionTransferPort {
+	void transferOwnership(Long fromParentId, Long toParentId, Long childId);
+}

--- a/src/main/java/com/kiero/mission/application/service/MissionCommandService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCommandService.java
@@ -138,7 +138,7 @@ public class MissionCommandService implements MissionCommandUseCase {
 		mission.complete();
 		child.addCoin(mission.getReward());
 
-		List<Parent> parents = parentChildLoadPort.findParentsByChildId(child.getId());
+		List<Parent> parents = parentChildLoadPort.findActiveParentsByChildId(child.getId());
 		List<Long> parentIds = parents.stream()
 			.map(Parent::getId)
 			.toList();

--- a/src/main/java/com/kiero/parent/adapter/in/web/ParentController.java
+++ b/src/main/java/com/kiero/parent/adapter/in/web/ParentController.java
@@ -29,6 +29,7 @@ import com.kiero.parent.application.dto.TodayProgressForParentResponse;
 import com.kiero.parent.application.exception.ParentSuccessCode;
 import com.kiero.parent.application.port.in.ParentChildQueryUseCase;
 import com.kiero.parent.application.port.in.ParentLoginUseCase;
+import com.kiero.parent.application.port.in.ParentWithdrawUseCase;
 import com.kiero.parent.application.service.ScheduleMissionFacade;
 import com.kiero.schedule.application.exception.ScheduleSuccessCode;
 
@@ -49,6 +50,7 @@ public class ParentController {
 
 	private final ParentChildQueryUseCase parentChildQueryUseCase;
 	private final ParentLoginUseCase parentLoginUseCase;
+	private final ParentWithdrawUseCase parentWithdrawUseCase;
 
 	private final InviteCodeUseCase inviteCodeUseCase;
 	private final ScheduleMissionFacade scheduleMissionFacade;
@@ -152,5 +154,16 @@ public class ParentController {
 		TodayProgressForParentResponse response = scheduleMissionFacade.getProgress(currentAuth.memberId(), childId);
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(ScheduleSuccessCode.CHILD_PROGRESS_GET_SUCCESS, response));
+	}
+
+	@PreAuthorize("hasRole('PARENT')")
+	@PostMapping("/withdraw")
+	public ResponseEntity<SuccessResponse<?>> withdraw(
+		@CurrentMember CurrentAuth currentAuth
+	) {
+		parentWithdrawUseCase.withdraw(currentAuth.memberId());
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(ParentSuccessCode.WITHDRAW_SUCCESS));
 	}
 }

--- a/src/main/java/com/kiero/parent/adapter/out/event/ParentWithdrawEventPublisherAdapter.java
+++ b/src/main/java/com/kiero/parent/adapter/out/event/ParentWithdrawEventPublisherAdapter.java
@@ -1,0 +1,18 @@
+package com.kiero.parent.adapter.out.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import com.kiero.parent.application.port.out.ParentWithdrawEventPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ParentWithdrawEventPublisherAdapter implements ParentWithdrawEventPort {
+
+	private final ApplicationEventPublisher publisher;
+
+	@Override
+	public void publish(Object event) { publisher.publishEvent(event); }
+}

--- a/src/main/java/com/kiero/parent/adapter/out/persistence/ParentChildPersistenceAdapter.java
+++ b/src/main/java/com/kiero/parent/adapter/out/persistence/ParentChildPersistenceAdapter.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import com.kiero.parent.application.port.out.ParentChildAccessPort;
+import com.kiero.parent.application.port.out.ParentChildDeletePort;
 import com.kiero.parent.application.port.out.ParentChildLoadPort;
 import com.kiero.parent.application.port.out.ParentChildSavePort;
 import com.kiero.parent.domain.Parent;
@@ -14,7 +15,8 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class ParentChildPersistenceAdapter implements ParentChildLoadPort, ParentChildAccessPort, ParentChildSavePort {
+public class ParentChildPersistenceAdapter implements ParentChildLoadPort, ParentChildAccessPort, ParentChildSavePort,
+	ParentChildDeletePort {
 
 	private final ParentChildRepository parentChildRepository;
 
@@ -41,5 +43,10 @@ public class ParentChildPersistenceAdapter implements ParentChildLoadPort, Paren
 	@Override
 	public ParentChild save(ParentChild parentChild) {
 		return parentChildRepository.save(parentChild);
+	}
+
+	@Override
+	public void deleteAllParentChildRelationsByParentId(Long parentId) {
+		parentChildRepository.deleteAllByParentId(parentId);
 	}
 }

--- a/src/main/java/com/kiero/parent/adapter/out/persistence/ParentChildPersistenceAdapter.java
+++ b/src/main/java/com/kiero/parent/adapter/out/persistence/ParentChildPersistenceAdapter.java
@@ -31,6 +31,11 @@ public class ParentChildPersistenceAdapter implements ParentChildLoadPort, Paren
 	}
 
 	@Override
+	public List<Parent> findActiveParentsByChildId(Long childId) {
+		return parentChildRepository.findActiveParentsByChildId(childId);
+	}
+
+	@Override
 	public List<ParentChild> findAllByParentId(Long parentId) {
 		return parentChildRepository.findAllByParentId(parentId);
 	}

--- a/src/main/java/com/kiero/parent/adapter/out/persistence/ParentChildRepository.java
+++ b/src/main/java/com/kiero/parent/adapter/out/persistence/ParentChildRepository.java
@@ -31,6 +31,14 @@ public interface ParentChildRepository extends JpaRepository<ParentChild, Long> 
 		""")
 	List<Parent> findParentsByChildId(@Param("childId") Long childId);
 
+	@Query("""
+		select pc.parent
+		from ParentChild pc
+		where pc.child.id = :childId
+		and pc.parent.role <> 'WITHDRAWN'
+		""")
+	List<Parent> findActiveParentsByChildId(@Param("childId") Long childId);
+
 	@Modifying
 	@Query("DELETE FROM ParentChild pc WHERE pc.child.id = :childId")
 	void deleteAllByChildId(@Param("childId") Long childId);

--- a/src/main/java/com/kiero/parent/adapter/out/persistence/ParentPersistenceAdapter.java
+++ b/src/main/java/com/kiero/parent/adapter/out/persistence/ParentPersistenceAdapter.java
@@ -1,0 +1,19 @@
+package com.kiero.parent.adapter.out.persistence;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.parent.application.port.out.ParentDeletePort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ParentPersistenceAdapter implements ParentDeletePort {
+
+	private final ParentRepository parentRepository;
+
+	@Override
+	public void deleteParent(Long parentId) {
+		parentRepository.deleteById(parentId);
+	}
+}

--- a/src/main/java/com/kiero/parent/adapter/out/redis/ParentWithdrawRedisAdapter.java
+++ b/src/main/java/com/kiero/parent/adapter/out/redis/ParentWithdrawRedisAdapter.java
@@ -1,0 +1,26 @@
+package com.kiero.parent.adapter.out.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.kiero.parent.application.port.out.ParentWithdrawNotificationPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ParentWithdrawRedisAdapter implements ParentWithdrawNotificationPort {
+
+	private static final String KEY_PREFIX = "child:";
+
+	@Value("${jwt.access-token-expire-time}")
+	private long accessTokenExpireTimeMs;
+
+	private final ParentWithdrawalRepository parentWithdrawalRepository;
+
+	@Override
+	public void storeWithdrawalMarker(Long childId) {
+		long ttlSeconds = accessTokenExpireTimeMs / 1000;
+		parentWithdrawalRepository.save(ParentWithdrawal.of(KEY_PREFIX + childId, childId, ttlSeconds));
+	}
+}

--- a/src/main/java/com/kiero/parent/adapter/out/redis/ParentWithdrawal.java
+++ b/src/main/java/com/kiero/parent/adapter/out/redis/ParentWithdrawal.java
@@ -1,0 +1,22 @@
+package com.kiero.parent.adapter.out.redis;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@RedisHash("parentWithdraw")
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class ParentWithdrawal {
+
+	@Id
+	private String id;
+
+	private Long childId;
+
+	@TimeToLive
+	private Long ttl;
+}

--- a/src/main/java/com/kiero/parent/adapter/out/redis/ParentWithdrawalRepository.java
+++ b/src/main/java/com/kiero/parent/adapter/out/redis/ParentWithdrawalRepository.java
@@ -1,0 +1,6 @@
+package com.kiero.parent.adapter.out.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ParentWithdrawalRepository extends CrudRepository<ParentWithdrawal, String> {
+}

--- a/src/main/java/com/kiero/parent/application/dto/ParentWithdrawnEvent.java
+++ b/src/main/java/com/kiero/parent/application/dto/ParentWithdrawnEvent.java
@@ -1,0 +1,6 @@
+package com.kiero.parent.application.dto;
+
+public record ParentWithdrawnEvent(
+	Long childId
+) {
+}

--- a/src/main/java/com/kiero/parent/application/exception/ParentSuccessCode.java
+++ b/src/main/java/com/kiero/parent/application/exception/ParentSuccessCode.java
@@ -16,6 +16,7 @@ public enum ParentSuccessCode implements BaseCode {
 	LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공하였습니다."),
 	GET_CHILDREN_SUCCESS(HttpStatus.OK, "자녀 목록 조회에 성공하였습니다."),
 	INVITE_STATUS_CHECKED(HttpStatus.OK, "초대 상태를 확인했습니다."),
+	WITHDRAW_SUCCESS(HttpStatus.OK, "서비스 탈퇴에 성공하였습니다."),
 
     /*
     201 CREATED

--- a/src/main/java/com/kiero/parent/application/port/in/ParentWithdrawUseCase.java
+++ b/src/main/java/com/kiero/parent/application/port/in/ParentWithdrawUseCase.java
@@ -1,0 +1,5 @@
+package com.kiero.parent.application.port.in;
+
+public interface ParentWithdrawUseCase {
+	void withdraw(Long parentId);
+}

--- a/src/main/java/com/kiero/parent/application/port/out/ParentChildDeletePort.java
+++ b/src/main/java/com/kiero/parent/application/port/out/ParentChildDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.parent.application.port.out;
+
+public interface ParentChildDeletePort {
+	void deleteAllParentChildRelationsByParentId(Long parentId);
+}

--- a/src/main/java/com/kiero/parent/application/port/out/ParentChildLoadPort.java
+++ b/src/main/java/com/kiero/parent/application/port/out/ParentChildLoadPort.java
@@ -9,4 +9,5 @@ public interface ParentChildLoadPort {
 	List<Long> findChildIdsByParentId(Long parentId);
 	List<ParentChild> findAllByParentId(Long parentId);
 	List<Parent> findParentsByChildId(Long childId);
+	List<Parent> findActiveParentsByChildId(Long childId);
 }

--- a/src/main/java/com/kiero/parent/application/port/out/ParentDeletePort.java
+++ b/src/main/java/com/kiero/parent/application/port/out/ParentDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.parent.application.port.out;
+
+public interface ParentDeletePort {
+	void deleteParent(Long parentId);
+}

--- a/src/main/java/com/kiero/parent/application/port/out/ParentWithdrawEventPort.java
+++ b/src/main/java/com/kiero/parent/application/port/out/ParentWithdrawEventPort.java
@@ -1,0 +1,5 @@
+package com.kiero.parent.application.port.out;
+
+public interface ParentWithdrawEventPort {
+	void publish(Object event);
+}

--- a/src/main/java/com/kiero/parent/application/port/out/ParentWithdrawNotificationPort.java
+++ b/src/main/java/com/kiero/parent/application/port/out/ParentWithdrawNotificationPort.java
@@ -1,0 +1,5 @@
+package com.kiero.parent.application.port.out;
+
+public interface ParentWithdrawNotificationPort {
+	void storeWithdrawalMarker(Long childId);
+}

--- a/src/main/java/com/kiero/parent/application/service/ParentWithdrawService.java
+++ b/src/main/java/com/kiero/parent/application/service/ParentWithdrawService.java
@@ -1,0 +1,87 @@
+package com.kiero.parent.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.global.auth.enums.Role;
+import com.kiero.global.auth.jwt.application.port.out.TokenCommandPort;
+import com.kiero.global.exception.KieroException;
+import com.kiero.parent.application.dto.ParentWithdrawnEvent;
+import com.kiero.parent.application.exception.ParentErrorCode;
+import com.kiero.parent.application.port.in.ParentWithdrawUseCase;
+import com.kiero.parent.application.port.out.ParentChildLoadPort;
+import com.kiero.parent.application.port.out.ParentLoadPort;
+import com.kiero.parent.application.port.out.ParentSavePort;
+import com.kiero.parent.application.port.out.ParentChildDeletePort;
+import com.kiero.parent.application.port.out.ParentWithdrawEventPort;
+import com.kiero.parent.application.port.out.ParentWithdrawNotificationPort;
+import com.kiero.parent.domain.Parent;
+import com.kiero.child.application.port.out.ChildDeletePort;
+import com.kiero.coupon.application.port.out.CouponDeletePort;
+import com.kiero.feed.application.port.out.FeedItemDeletePort;
+import com.kiero.mission.application.port.out.MissionDeletePort;
+import com.kiero.schedule.application.port.out.ScheduleDeletePort;
+import com.kiero.terms.application.port.out.TermsAgreementDeletePort;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ParentWithdrawService implements ParentWithdrawUseCase {
+
+	private final ParentLoadPort parentLoadPort;
+	private final ParentSavePort parentSavePort;
+	private final ParentChildLoadPort parentChildLoadPort;
+	private final ParentChildDeletePort parentWithdrawDeletePort;
+	private final ParentWithdrawEventPort parentWithdrawEventPort;
+	private final ParentWithdrawNotificationPort parentWithdrawNotificationPort;
+	private final TokenCommandPort tokenCommandPort;
+	private final ScheduleDeletePort scheduleDeletePort;
+	private final MissionDeletePort missionDeletePort;
+	private final CouponDeletePort couponDeletePort;
+	private final FeedItemDeletePort feedItemDeletePort;
+	private final TermsAgreementDeletePort termsAgreementDeletePort;
+	private final ChildDeletePort childDeletePort;
+
+	@Override
+	@Transactional
+	public void withdraw(Long parentId) {
+		Parent parent = parentLoadPort.findById(parentId)
+			.orElseThrow(() -> new KieroException(ParentErrorCode.PARENT_NOT_FOUND));
+
+		List<Long> childIds = parentChildLoadPort.findChildIdsByParentId(parentId);
+
+		// 탈퇴하려는 부모가 유일한 부모인 아이 List
+		List<Long> soloChildIds = childIds.stream()
+			.filter(childId -> parentChildLoadPort.findParentsByChildId(childId).size() == 1)
+			.toList();
+
+		// 부모-자녀 관계 삭제
+		parentWithdrawDeletePort.deleteAllParentChildRelationsByParentId(parentId);
+
+		// 부모의 약관 동의 내역 삭제
+		termsAgreementDeletePort.deleteAllByParentId(parentId);
+
+		// 개인정보 익명화
+		parent.withdraw();
+
+		// 부모 refresh token 삭제
+		tokenCommandPort.deleteRefreshToken(parentId, Role.PARENT);
+
+		// 유일한 부모였던 아이: 관련 리소스 삭제 + 알림 + refresh token 삭제
+		for (Long childId : soloChildIds) {
+			scheduleDeletePort.deleteAllByChildId(childId);
+			missionDeletePort.deleteAllByChildId(childId);
+			couponDeletePort.deleteAllByChildId(childId);
+			feedItemDeletePort.deleteAllByChildId(childId);
+
+			parentWithdrawEventPort.publish(new ParentWithdrawnEvent(childId));
+			parentWithdrawNotificationPort.storeWithdrawalMarker(childId);
+			tokenCommandPort.deleteRefreshToken(childId, Role.CHILD);
+			childDeletePort.deleteById(childId);
+		}
+	}
+}

--- a/src/main/java/com/kiero/parent/application/service/ParentWithdrawService.java
+++ b/src/main/java/com/kiero/parent/application/service/ParentWithdrawService.java
@@ -1,28 +1,36 @@
 package com.kiero.parent.application.service;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.kiero.child.application.port.out.ChildDeletePort;
+import com.kiero.coupon.application.port.out.CouponDeletePort;
+import com.kiero.coupon.application.port.out.CouponTransferPort;
+import com.kiero.feed.application.port.out.FeedItemDeletePort;
+import com.kiero.feed.application.port.out.FeedItemTransferPort;
 import com.kiero.global.auth.enums.Role;
 import com.kiero.global.auth.jwt.application.port.out.TokenCommandPort;
 import com.kiero.global.exception.KieroException;
+import com.kiero.mission.application.port.out.MissionDeletePort;
+import com.kiero.mission.application.port.out.MissionTransferPort;
 import com.kiero.parent.application.dto.ParentWithdrawnEvent;
 import com.kiero.parent.application.exception.ParentErrorCode;
 import com.kiero.parent.application.port.in.ParentWithdrawUseCase;
-import com.kiero.parent.application.port.out.ParentChildLoadPort;
-import com.kiero.parent.application.port.out.ParentLoadPort;
-import com.kiero.parent.application.port.out.ParentSavePort;
 import com.kiero.parent.application.port.out.ParentChildDeletePort;
+import com.kiero.parent.application.port.out.ParentChildLoadPort;
+import com.kiero.parent.application.port.out.ParentDeletePort;
+import com.kiero.parent.application.port.out.ParentLoadPort;
 import com.kiero.parent.application.port.out.ParentWithdrawEventPort;
 import com.kiero.parent.application.port.out.ParentWithdrawNotificationPort;
 import com.kiero.parent.domain.Parent;
-import com.kiero.child.application.port.out.ChildDeletePort;
-import com.kiero.coupon.application.port.out.CouponDeletePort;
-import com.kiero.feed.application.port.out.FeedItemDeletePort;
-import com.kiero.mission.application.port.out.MissionDeletePort;
 import com.kiero.schedule.application.port.out.ScheduleDeletePort;
+import com.kiero.schedule.application.port.out.ScheduleTransferPort;
 import com.kiero.terms.application.port.out.TermsAgreementDeletePort;
 
 import lombok.RequiredArgsConstructor;
@@ -33,16 +41,20 @@ import lombok.RequiredArgsConstructor;
 public class ParentWithdrawService implements ParentWithdrawUseCase {
 
 	private final ParentLoadPort parentLoadPort;
-	private final ParentSavePort parentSavePort;
 	private final ParentChildLoadPort parentChildLoadPort;
 	private final ParentChildDeletePort parentWithdrawDeletePort;
 	private final ParentWithdrawEventPort parentWithdrawEventPort;
 	private final ParentWithdrawNotificationPort parentWithdrawNotificationPort;
+	private final ParentDeletePort parentDeletePort;
 	private final TokenCommandPort tokenCommandPort;
 	private final ScheduleDeletePort scheduleDeletePort;
+	private final ScheduleTransferPort scheduleTransferPort;
 	private final MissionDeletePort missionDeletePort;
+	private final MissionTransferPort missionTransferPort;
 	private final CouponDeletePort couponDeletePort;
+	private final CouponTransferPort couponTransferPort;
 	private final FeedItemDeletePort feedItemDeletePort;
+	private final FeedItemTransferPort feedItemTransferPort;
 	private final TermsAgreementDeletePort termsAgreementDeletePort;
 	private final ChildDeletePort childDeletePort;
 
@@ -54,10 +66,33 @@ public class ParentWithdrawService implements ParentWithdrawUseCase {
 
 		List<Long> childIds = parentChildLoadPort.findChildIdsByParentId(parentId);
 
-		// 탈퇴하려는 부모가 유일한 부모인 아이 List
-		List<Long> soloChildIds = childIds.stream()
-			.filter(childId -> parentChildLoadPort.findParentsByChildId(childId).size() == 1)
-			.toList();
+		// 아이별로 후계 부모 계산
+		List<Long> soloChildIds = new ArrayList<>();
+		Map<Long, Long> childToSuccessorMap = new HashMap<>(); // childId -> 후계 부모 ID
+
+		for (Long childId : childIds) {
+			List<Parent> remainingParents = parentChildLoadPort.findParentsByChildId(childId)
+				.stream()
+				.filter(p -> !p.getId().equals(parentId))
+				.sorted(Comparator.comparing(Parent::getCreatedAt))
+				.toList();
+
+			if (remainingParents.isEmpty()) {
+				soloChildIds.add(childId);
+			} else {
+				childToSuccessorMap.put(childId, remainingParents.get(0).getId()); // 가장 먼저 생성된 부모
+			}
+		}
+
+		// 복수 부모 아이: 탈퇴 부모의 리소스를 후계 부모에게 이전
+		for (Map.Entry<Long, Long> entry : childToSuccessorMap.entrySet()) {
+			Long childId = entry.getKey();
+			Long successorId = entry.getValue();
+			scheduleTransferPort.transferOwnership(parentId, successorId, childId);
+			missionTransferPort.transferOwnership(parentId, successorId, childId);
+			couponTransferPort.transferOwnership(parentId, successorId, childId);
+			feedItemTransferPort.transferOwnership(parentId, successorId, childId);
+		}
 
 		// 부모-자녀 관계 삭제
 		parentWithdrawDeletePort.deleteAllParentChildRelationsByParentId(parentId);
@@ -65,13 +100,13 @@ public class ParentWithdrawService implements ParentWithdrawUseCase {
 		// 부모의 약관 동의 내역 삭제
 		termsAgreementDeletePort.deleteAllByParentId(parentId);
 
-		// 개인정보 익명화
-		parent.withdraw();
-
 		// 부모 refresh token 삭제
 		tokenCommandPort.deleteRefreshToken(parentId, Role.PARENT);
 
-		// 유일한 부모였던 아이: 관련 리소스 삭제 + 알림 + refresh token 삭제
+		// 부모 하드딜리트
+		parentDeletePort.deleteParent(parentId);
+
+		// 유일한 부모였던 아이: 관련 리소스 삭제 + 알림 + refresh token 삭제 + 아이 삭제
 		for (Long childId : soloChildIds) {
 			scheduleDeletePort.deleteAllByChildId(childId);
 			missionDeletePort.deleteAllByChildId(childId);

--- a/src/main/java/com/kiero/parent/domain/Parent.java
+++ b/src/main/java/com/kiero/parent/domain/Parent.java
@@ -31,10 +31,10 @@ public class Parent extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = ParentTableConstants.COLUMN_NAME, nullable = false)
+	@Column(name = ParentTableConstants.COLUMN_NAME, nullable = true)
 	private String name;
 
-	@Column(name = ParentTableConstants.COLUMN_EMAIL, nullable = false)
+	@Column(name = ParentTableConstants.COLUMN_EMAIL, nullable = true)
 	private String email;
 
 	@Column(name = ParentTableConstants.COLUMN_IMAGE, nullable = true)
@@ -48,7 +48,7 @@ public class Parent extends BaseTimeEntity {
 	@Column(name = ParentTableConstants.COLUMN_PROVIDER, nullable = false)
 	private Provider provider;
 
-	@Column(name = ParentTableConstants.COLUMN_SOCIAL_ID, nullable = false)
+	@Column(name = ParentTableConstants.COLUMN_SOCIAL_ID, nullable = true)
 	private String socialId;
 
 	public static Parent create(
@@ -73,6 +73,14 @@ public class Parent extends BaseTimeEntity {
 		this.name = name;
 		this.email = email;
 		this.image = image;
+	}
+
+	public void withdraw() {
+		this.name = null;
+		this.email = null;
+		this.image = null;
+		this.socialId = null;
+		this.role = Role.WITHDRAWN;
 	}
 
 }

--- a/src/main/java/com/kiero/parent/domain/Parent.java
+++ b/src/main/java/com/kiero/parent/domain/Parent.java
@@ -31,10 +31,10 @@ public class Parent extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = ParentTableConstants.COLUMN_NAME, nullable = true)
+	@Column(name = ParentTableConstants.COLUMN_NAME, nullable = false)
 	private String name;
 
-	@Column(name = ParentTableConstants.COLUMN_EMAIL, nullable = true)
+	@Column(name = ParentTableConstants.COLUMN_EMAIL, nullable = false)
 	private String email;
 
 	@Column(name = ParentTableConstants.COLUMN_IMAGE, nullable = true)
@@ -48,7 +48,7 @@ public class Parent extends BaseTimeEntity {
 	@Column(name = ParentTableConstants.COLUMN_PROVIDER, nullable = false)
 	private Provider provider;
 
-	@Column(name = ParentTableConstants.COLUMN_SOCIAL_ID, nullable = true)
+	@Column(name = ParentTableConstants.COLUMN_SOCIAL_ID, nullable = false)
 	private String socialId;
 
 	@Column(name = ParentTableConstants.COLUMN_APPLE_REFRESH_TOKEN)
@@ -78,14 +78,6 @@ public class Parent extends BaseTimeEntity {
 		this.image = image;
 	}
 
-
-	public void withdraw() {
-		this.name = null;
-		this.email = null;
-		this.image = null;
-		this.socialId = null;
-		this.role = Role.WITHDRAWN;
-  }
 
 	public void updateAppleProfile(final String email) {
 		this.email = email;

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDeleteAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDeleteAdapter.java
@@ -1,0 +1,31 @@
+package com.kiero.schedule.adapter.out.persistence;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.schedule.application.port.out.ScheduleDeletePort;
+import com.kiero.schedule.domain.Schedule;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduleDeleteAdapter implements ScheduleDeletePort {
+
+	private final ScheduleRepository scheduleRepository;
+	private final ScheduleDetailRepository scheduleDetailRepository;
+	private final DiscardedScheduleRepository discardedScheduleRepository;
+	private final ScheduleRepeatDaysRepository scheduleRepeatDaysRepository;
+
+	@Override
+	public void deleteAllByChildId(Long childId) {
+		List<Schedule> schedules = scheduleRepository.findAllByChildId(childId);
+		for (Schedule schedule : schedules) {
+			scheduleRepeatDaysRepository.deleteAllByScheduleId(schedule.getId());
+			discardedScheduleRepository.deleteByScheduleId(schedule.getId());
+			scheduleDetailRepository.deleteAllByScheduleId(schedule.getId());
+		}
+		scheduleRepository.deleteAllById(schedules.stream().map(Schedule::getId).toList());
+	}
+}

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/SchedulePersistenceAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/SchedulePersistenceAdapter.java
@@ -6,13 +6,14 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 
 import com.kiero.schedule.application.port.out.SchedulePersistencePort;
+import com.kiero.schedule.application.port.out.ScheduleTransferPort;
 import com.kiero.schedule.domain.Schedule;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class SchedulePersistenceAdapter implements SchedulePersistencePort {
+public class SchedulePersistenceAdapter implements SchedulePersistencePort, ScheduleTransferPort {
 
 	private final ScheduleRepository scheduleRepository;
 
@@ -49,6 +50,11 @@ public class SchedulePersistenceAdapter implements SchedulePersistencePort {
 	@Override
 	public void deleteObsoleteNonRecurringSchedules() {
 		scheduleRepository.deleteObsoleteNonRecurringSchedules();
+	}
+
+	@Override
+	public void transferOwnership(Long fromParentId, Long toParentId, Long childId) {
+		scheduleRepository.transferOwnershipByParentIdAndChildId(fromParentId, toParentId, childId);
 	}
 
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.kiero.schedule.domain.Schedule;
@@ -27,4 +28,8 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
       )
   """)
 	void deleteObsoleteNonRecurringSchedules();
+
+	@Modifying
+	@Query(value = "UPDATE schedule SET parent_id = :newParentId WHERE parent_id = :oldParentId AND child_id = :childId", nativeQuery = true)
+	void transferOwnershipByParentIdAndChildId(@Param("oldParentId") Long oldParentId, @Param("newParentId") Long newParentId, @Param("childId") Long childId);
 }

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleDeletePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.schedule.application.port.out;
+
+public interface ScheduleDeletePort {
+	void deleteAllByChildId(Long childId);
+}

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleTransferPort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleTransferPort.java
@@ -1,0 +1,5 @@
+package com.kiero.schedule.application.port.out;
+
+public interface ScheduleTransferPort {
+	void transferOwnership(Long fromParentId, Long toParentId, Long childId);
+}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -203,7 +203,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			throw new KieroException(ScheduleErrorCode.SCHEDULE_COULD_NOT_BE_SKIPPED);
 		}
 
-		List<Long> parentIds = parentChildLoadPort.findParentsByChildId(childId).stream()
+		List<Long> parentIds = parentChildLoadPort.findActiveParentsByChildId(childId).stream()
 				.map(Parent::getId)
 				.toList();
 
@@ -232,7 +232,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 		scheduleDetail.changeScheduleStatus(ScheduleStatus.VERIFIED);
 		scheduleDetail.changeImageUrl(request.imageUrl());
 
-		List<Parent> parents = parentChildLoadPort.findParentsByChildId(childId);
+		List<Parent> parents = parentChildLoadPort.findActiveParentsByChildId(childId);
 		List<Long> parentIds = parents.stream()
 			.map(Parent::getId)
 			.toList();
@@ -286,7 +286,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			earnedCoinAmount = ALL_SCHEDULE_SUCCESS_REWARD;
 		}
 
-		List<Parent> parents = parentChildLoadPort.findParentsByChildId(child.getId());
+		List<Parent> parents = parentChildLoadPort.findActiveParentsByChildId(child.getId());
 		List<Long> parentIds = parents.stream()
 			.map(Parent::getId)
 			.toList();

--- a/src/main/java/com/kiero/terms/adapter/out/persistence/TermsAgreementPersistenceAdapter.java
+++ b/src/main/java/com/kiero/terms/adapter/out/persistence/TermsAgreementPersistenceAdapter.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+import com.kiero.terms.application.port.out.TermsAgreementDeletePort;
 import com.kiero.terms.application.port.out.TermsAgreementLoadPort;
 import com.kiero.terms.application.port.out.TermsAgreementPersistencePort;
 import com.kiero.terms.domain.TermsAgreement;
@@ -12,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class TermsAgreementPersistenceAdapter implements TermsAgreementLoadPort, TermsAgreementPersistencePort {
+public class TermsAgreementPersistenceAdapter implements TermsAgreementLoadPort, TermsAgreementPersistencePort, TermsAgreementDeletePort {
 
 	private final TermsAgreementRepository termsAgreementRepository;
 
@@ -29,5 +30,10 @@ public class TermsAgreementPersistenceAdapter implements TermsAgreementLoadPort,
 	@Override
 	public void save(TermsAgreement termsAgreement) {
 		termsAgreementRepository.save(termsAgreement);
+	}
+
+	@Override
+	public void deleteAllByParentId(Long parentId) {
+		termsAgreementRepository.deleteAllByParentId(parentId);
 	}
 }

--- a/src/main/java/com/kiero/terms/adapter/out/persistence/TermsAgreementRepository.java
+++ b/src/main/java/com/kiero/terms/adapter/out/persistence/TermsAgreementRepository.java
@@ -27,4 +27,6 @@ public interface TermsAgreementRepository extends JpaRepository<TermsAgreement, 
 			AND ta.withdrawnAt IS NULL
 		""")
 	List<Long> findActiveAgreedTermsIdsByParentId(@Param("parentId") Long parentId);
+
+	void deleteAllByParentId(Long parentId);
 }

--- a/src/main/java/com/kiero/terms/application/port/out/TermsAgreementDeletePort.java
+++ b/src/main/java/com/kiero/terms/application/port/out/TermsAgreementDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.terms.application.port.out;
+
+public interface TermsAgreementDeletePort {
+	void deleteAllByParentId(Long parentId);
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #241

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 부모의 탈퇴 api를 구현하였습니다.
```
연결된 부모가 2명 이상일 경우, 탈퇴한 부모가 생성한 리소스는 삭제되지 않고 아이 뷰에서 확인 가능해야 합니다. 
우리 서비스에서는 엔터티에서 직접 다른 엔터티를 @ManyToOne으로 참조하기 때문에, 
탈퇴한 부모 레코드를 hard delete하면 참조무결성 문제가 발생합니다. 
=> 아이와 연결된 남아있는 부모 중, 가장 먼저 생성된 부모를 후계 부모로 설정하여 탈퇴 부모와 관련있는 리소스들의 부모 참조를 변경합니다.

연결된 부모가 1명일 경우, 연관된 모든 데이터(아이 포함)이 삭제됩니다. 
아이가 앱에 진입하여 화면을 보고 있을 경우, 즉시 로그아웃되어야 합니다. 
부모 탈퇴 시 아이에게 sse로 탈퇴 이벤트를 전송해, 클라이언트 측에서 강제 로그아웃을 수행하도록 의도하였습니다. 
아이의 refresh token을 삭제하고, 부모의 탈퇴 세션을 생성합니다(밑에서 설명).

아이와 연결된 부모 수에 상관없이, 부모 탈퇴 시 부모의 약관동의 내역, 부모의 refresh token, parentChild 관계를 삭제합니다.
```

- 부모 탈퇴 세션 조회 api를 구현하였습니다. 
```
한 명 뿐인 부모가 탈퇴하였을 때, 즉시 아이의 앱 이용은 차단되어야합니다. 
아이가 앱에 진입해 있을 때는 sse 이벤트를 받아 즉시 강제로그아웃 처리가 되지만, 
앱에 진입해 않을 땐, 유효한 access token을 사용하여 앱에 진입이 가능합니다. 

때문에, 아이가 앱에 접속 시 최초 1회 부모의 탈퇴 세션 조회 api를 호출하여, 부모가 탈퇴하였다면 즉시 강제 로그아웃되도록 합니다. 

세션의 TTL은 키어로 JWT의 access token TTL로 설정하였습니다. 
아이의 access token이 만료되어도 refresh token을 삭제하였기 때문에, 
더 이상 앱 진입이 불가하여, 이 경우에는 세션을 조회할 필요가 없기 때문입니다.  
```


## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 부모 탈퇴 api
<img width="871" height="390" alt="image" src="https://github.com/user-attachments/assets/bf877fce-fb1f-4ca6-b9f1-36b854abce2c" />

### 부모 탈퇴여부 조회 api
<img width="869" height="534" alt="image" src="https://github.com/user-attachments/assets/c05ea3f4-1046-474d-beb6-6a0e0465ef77" />

### 부모의 탈퇴 이벤트 수신
<img width="866" height="671" alt="image" src="https://github.com/user-attachments/assets/a32a7610-f8f5-435f-9667-caea61431847" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
하다보니 신경쓸 게 좀 있었네요.. api도 추가되어 머지된 후 디코 스레드를 통해 api 추가 + 추가 이유를 공지할 예정입니다~
changed file이 많은데 withdrawService 쪽만 꼼꼼히 봐주셔도 댈듯 합니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 부모 탈퇴 기능 추가: 부모가 서비스에서 탈퇴할 수 있으며, 탈퇴 시 리소스는 자동으로 처리됩니다.
  * 부모 탈퇴 상태 조회: 자녀가 보호자의 탈퇴 여부를 확인할 수 있는 기능 추가.
  * 부모 탈퇴 알림: 탈퇴 시 자녀에게 실시간 알림 전송.

* **Improvements**
  * 활성 보호자 기준 조회 강화: 피드, 미션, 일정 관련 이벤트가 탈퇴하지 않은 보호자만 대상으로 전송되도록 개선.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Kiero/Kiero-Server/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->