### PR TITLE
[feat] #249 - 부모, 아이 마이페이지 조회 api 구현 

### DIFF
--- a/src/main/java/com/kiero/child/application/dto/ChildMeResponse.java
+++ b/src/main/java/com/kiero/child/application/dto/ChildMeResponse.java
@@ -10,14 +10,16 @@ public record ChildMeResponse(
         String lastName,
         String firstName,
         int coinAmount,
-        String today
+        String today,
+        boolean isPushNotificationEnabled
 ) {
     public static ChildMeResponse from(Child child, LocalDate today) {
         return new ChildMeResponse(
                 child.getLastName(),
                 child.getFirstName(),
                 child.getCoinAmount(),
-                today.format(FORMATTER)
+                today.format(FORMATTER),
+                child.isPushNotificationEnabled()
         );
     }
 

--- a/src/main/java/com/kiero/parent/adapter/in/web/ParentController.java
+++ b/src/main/java/com/kiero/parent/adapter/in/web/ParentController.java
@@ -18,18 +18,20 @@ import org.springframework.web.bind.annotation.RestController;
 import com.kiero.global.auth.annotation.CurrentMember;
 import com.kiero.global.auth.client.dto.SocialLoginRequest;
 import com.kiero.global.auth.dto.CurrentAuth;
-import com.kiero.parent.application.dto.AppleLoginRequest;
 import com.kiero.global.response.dto.SuccessResponse;
 import com.kiero.invitation.application.port.in.InviteCodeUseCase;
+import com.kiero.parent.application.dto.AppleLoginRequest;
 import com.kiero.parent.application.dto.ChildInfoResponse;
 import com.kiero.parent.application.dto.InviteCodeCreateRequest;
 import com.kiero.parent.application.dto.InviteCodeCreateResponse;
 import com.kiero.parent.application.dto.InviteStatusResponse;
 import com.kiero.parent.application.dto.ParentLoginResponse;
+import com.kiero.parent.application.dto.ParentMeResponse;
 import com.kiero.parent.application.dto.TodayProgressForParentResponse;
 import com.kiero.parent.application.exception.ParentSuccessCode;
 import com.kiero.parent.application.port.in.ParentChildQueryUseCase;
 import com.kiero.parent.application.port.in.ParentLoginUseCase;
+import com.kiero.parent.application.port.in.ParentQueryUseCase;
 import com.kiero.parent.application.port.in.ParentWithdrawUseCase;
 import com.kiero.parent.application.service.ScheduleMissionFacade;
 import com.kiero.schedule.application.exception.ScheduleSuccessCode;
@@ -52,6 +54,7 @@ public class ParentController {
 	private final ParentChildQueryUseCase parentChildQueryUseCase;
 	private final ParentLoginUseCase parentLoginUseCase;
 	private final ParentWithdrawUseCase parentWithdrawUseCase;
+	private final ParentQueryUseCase parentQueryUseCase;
 
 	private final InviteCodeUseCase inviteCodeUseCase;
 	private final ScheduleMissionFacade scheduleMissionFacade;
@@ -180,7 +183,7 @@ public class ParentController {
 			.body(SuccessResponse.of(ScheduleSuccessCode.CHILD_PROGRESS_GET_SUCCESS, response));
 	}
 
-	@PreAuthorize("hasRole('PARENT')")
+	@PreAuthorize("hasAnyRole('PARENT', 'ADMIN')")
 	@PostMapping("/withdraw")
 	public ResponseEntity<SuccessResponse<?>> withdraw(
 		@CurrentMember CurrentAuth currentAuth
@@ -189,5 +192,16 @@ public class ParentController {
 
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(ParentSuccessCode.WITHDRAW_SUCCESS));
+	}
+
+	@PreAuthorize("hasAnyRole('PARENT', 'ADMIN')")
+	@GetMapping("/me")
+	public ResponseEntity<SuccessResponse<ParentMeResponse>> getMyInfo(
+		@CurrentMember CurrentAuth currentAuth
+	) {
+		ParentMeResponse response = parentQueryUseCase.getMyInfo(currentAuth.memberId());
+
+		return ResponseEntity.ok()
+			.body(SuccessResponse.of(ParentSuccessCode.GET_MY_INFO_SUCCESS, response));
 	}
 }

--- a/src/main/java/com/kiero/parent/application/dto/ParentMeResponse.java
+++ b/src/main/java/com/kiero/parent/application/dto/ParentMeResponse.java
@@ -1,0 +1,9 @@
+package com.kiero.parent.application.dto;
+
+public record ParentMeResponse(
+	String image,
+	String name,
+	boolean hasPendingChildSession,
+	boolean pushNotificationEnabled
+) {
+}

--- a/src/main/java/com/kiero/parent/application/exception/ParentSuccessCode.java
+++ b/src/main/java/com/kiero/parent/application/exception/ParentSuccessCode.java
@@ -17,6 +17,7 @@ public enum ParentSuccessCode implements BaseCode {
 	GET_CHILDREN_SUCCESS(HttpStatus.OK, "자녀 목록 조회에 성공하였습니다."),
 	INVITE_STATUS_CHECKED(HttpStatus.OK, "초대 상태를 확인했습니다."),
 	WITHDRAW_SUCCESS(HttpStatus.OK, "서비스 탈퇴에 성공하였습니다."),
+	GET_MY_INFO_SUCCESS(HttpStatus.OK, "프로필 정보가 조회되었습니다."),
 
     /*
     201 CREATED

--- a/src/main/java/com/kiero/parent/application/port/in/ParentQueryUseCase.java
+++ b/src/main/java/com/kiero/parent/application/port/in/ParentQueryUseCase.java
@@ -1,0 +1,10 @@
+package com.kiero.parent.application.port.in;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.parent.application.dto.ParentMeResponse;
+
+@Component
+public interface ParentQueryUseCase {
+	ParentMeResponse getMyInfo(Long parentId);
+}

--- a/src/main/java/com/kiero/parent/application/service/ParentQueryService.java
+++ b/src/main/java/com/kiero/parent/application/service/ParentQueryService.java
@@ -1,0 +1,38 @@
+package com.kiero.parent.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.global.exception.KieroException;
+import com.kiero.invitation.application.port.out.InviteCodeQueryPort;
+import com.kiero.parent.application.dto.ParentMeResponse;
+import com.kiero.parent.application.exception.ParentErrorCode;
+import com.kiero.parent.application.port.in.ParentQueryUseCase;
+import com.kiero.parent.application.port.out.ParentLoadPort;
+import com.kiero.parent.domain.Parent;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ParentQueryService implements ParentQueryUseCase {
+
+	private final ParentLoadPort parentLoadPort;
+	private final InviteCodeQueryPort inviteCodeQueryPort;
+
+	@Override
+	@Transactional(readOnly = true)
+	public ParentMeResponse getMyInfo(Long parentId) {
+		Parent parent = parentLoadPort.findById(parentId)
+			.orElseThrow(() -> new KieroException(ParentErrorCode.PARENT_NOT_FOUND));
+
+		boolean hasPendingChildSession = inviteCodeQueryPort.findByParentKey(parentId.toString()).isPresent();
+
+		return new ParentMeResponse(
+			parent.getImage(),
+			parent.getName(),
+			hasPendingChildSession,
+			parent.isPushNotificationEnabled()
+		);
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #249

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 부모의 마이페이지 조회 api를 구현하였습니다.
초대코드 생성 시 생성되는 redis 세션으로 연결대기중인 아이가 있는지 확인하고, 연결대기중인 아이가 있는지 boolean 응답을 포함하여 반환합니다.

- 아이의 마이페이지 조회 응답에 알림수신여부를 추가하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 연결 대기 세션 존재하지 않을 때, 부모의 마이페이지 조회 응답
<img width="858" height="577" alt="image" src="https://github.com/user-attachments/assets/a7bcb77e-5aa3-4279-ab5d-ac314eca8749" />

### 초대코드 발급 후, 부모의 마이페이지 조회 응답
<img width="861" height="560" alt="image" src="https://github.com/user-attachments/assets/b17dbdd8-9e0e-4119-9bc4-579eeca56635" />

### 아이가 초대코드 연결 후, 부모의 마이페이지 조회 응답
<img width="858" height="577" alt="image" src="https://github.com/user-attachments/assets/4a880725-0b32-4a78-85b5-19a117c6c217" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 부모가 자신의 프로필 정보(이름, 이미지 등)를 조회할 수 있는 새로운 엔드포인트 추가
  * 부모 프로필에 보류 중인 자녀 세션 여부 표시
  * 프로필 응답에 푸시 알림 설정 상태 포함

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Kiero/Kiero-Server/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->