### PR TITLE
[Refactor] #254 - 푸시 페이로드 targetId 데이터 추가

### DIFF
--- a/src/main/java/com/kiero/coupon/application/dto/CouponPurchasedEvent.java
+++ b/src/main/java/com/kiero/coupon/application/dto/CouponPurchasedEvent.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record CouponPurchasedEvent(
 	List<Long> parentIds,
 	Long childId,
+	Long couponId,
 	String couponName
 ) {
 }

--- a/src/main/java/com/kiero/coupon/application/service/CouponCommandService.java
+++ b/src/main/java/com/kiero/coupon/application/service/CouponCommandService.java
@@ -137,7 +137,7 @@ public class CouponCommandService implements CouponCommandUseCase {
 			coupon.getPrice(),
 			LocalDateTime.now()
 		));
-		couponEventPort.publish(new CouponPurchasedEvent(parentIds, child.getId(), coupon.getName()));
+		couponEventPort.publish(new CouponPurchasedEvent(parentIds, child.getId(), coupon.getId(), coupon.getName()));
 
 		return new CouponResponse(coupon.getId(), coupon.getName(), coupon.getPrice());
 	}

--- a/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemPersistenceAdapter.java
+++ b/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemPersistenceAdapter.java
@@ -1,5 +1,6 @@
 package com.kiero.feed.adapter.out.persistence;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -57,6 +58,21 @@ public class FeedItemPersistenceAdapter implements FeedItemCommandPort, FeedItem
 	@Override
 	public Optional<FeedItem> findByParentIdAndScheduleDetailIdAndEventType(Long parentId, Long scheduleDetailId, EventType eventType) {
 		return feedItemRepository.findByParentIdAndScheduleDetailIdAndEventType(parentId, String.valueOf(scheduleDetailId), eventType.name());
+	}
+
+	@Override
+	public Optional<FeedItem> findByParentIdAndMissionId(Long parentId, Long missionId) {
+		return feedItemRepository.findByParentIdAndMissionId(parentId, String.valueOf(missionId));
+	}
+
+	@Override
+	public Optional<FeedItem> findByParentIdAndCouponId(Long parentId, Long couponId) {
+		return feedItemRepository.findByParentIdAndCouponId(parentId, String.valueOf(couponId));
+	}
+
+	@Override
+	public Optional<FeedItem> findByParentAndChildComplete(Long parentId, Long childId, LocalDate date) {
+		return feedItemRepository.findByParentAndChildComplete(parentId, childId, date);
 	}
 
 	@Override

--- a/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemRepository.java
+++ b/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemRepository.java
@@ -66,6 +66,7 @@ public interface FeedItemRepository extends JpaRepository<FeedItem, Long> {
 		WHERE f.parent_id = :parentId
 		  AND f.event_type = :eventType
 		  AND JSON_UNQUOTE(JSON_EXTRACT(f.metadata, '$.scheduleDetailId')) = :scheduleDetailId
+		ORDER BY f.id DESC
 		LIMIT 1
 	""", nativeQuery = true)
 	Optional<FeedItem> findByParentIdAndScheduleDetailIdAndEventType(
@@ -90,6 +91,7 @@ public interface FeedItemRepository extends JpaRepository<FeedItem, Long> {
 		WHERE f.parent_id = :parentId
 		  AND f.event_type = 'MISSION'
 		  AND JSON_UNQUOTE(JSON_EXTRACT(f.metadata, '$.missionId')) = :missionId
+		ORDER BY f.id DESC
 		LIMIT 1
 	""", nativeQuery = true)
 	Optional<FeedItem> findByParentIdAndMissionId(
@@ -103,6 +105,7 @@ public interface FeedItemRepository extends JpaRepository<FeedItem, Long> {
 		WHERE f.parent_id = :parentId
 		  AND f.event_type = 'COUPON'
 		  AND JSON_UNQUOTE(JSON_EXTRACT(f.metadata, '$.couponId')) = :couponId
+		ORDER BY f.id DESC
 		LIMIT 1
 	""", nativeQuery = true)
 	Optional<FeedItem> findByParentIdAndCouponId(
@@ -117,6 +120,7 @@ public interface FeedItemRepository extends JpaRepository<FeedItem, Long> {
 		  AND f.child_id = :childId
 		  AND f.event_type = 'COMPLETE'
 		  AND DATE(f.occurred_at) = :date
+		ORDER BY f.id DESC
 		LIMIT 1
 	""", nativeQuery = true)
 	Optional<FeedItem> findByParentAndChildComplete(

--- a/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemRepository.java
+++ b/src/main/java/com/kiero/feed/adapter/out/persistence/FeedItemRepository.java
@@ -84,6 +84,47 @@ public interface FeedItemRepository extends JpaRepository<FeedItem, Long> {
 		@Param("parentId") Long parentId
 	);
 
+	@Query(value = """
+		SELECT *
+		FROM feed_item f
+		WHERE f.parent_id = :parentId
+		  AND f.event_type = 'MISSION'
+		  AND JSON_UNQUOTE(JSON_EXTRACT(f.metadata, '$.missionId')) = :missionId
+		LIMIT 1
+	""", nativeQuery = true)
+	Optional<FeedItem> findByParentIdAndMissionId(
+		@Param("parentId") Long parentId,
+		@Param("missionId") String missionId
+	);
+
+	@Query(value = """
+		SELECT *
+		FROM feed_item f
+		WHERE f.parent_id = :parentId
+		  AND f.event_type = 'COUPON'
+		  AND JSON_UNQUOTE(JSON_EXTRACT(f.metadata, '$.couponId')) = :couponId
+		LIMIT 1
+	""", nativeQuery = true)
+	Optional<FeedItem> findByParentIdAndCouponId(
+		@Param("parentId") Long parentId,
+		@Param("couponId") String couponId
+	);
+
+	@Query(value = """
+		SELECT *
+		FROM feed_item f
+		WHERE f.parent_id = :parentId
+		  AND f.child_id = :childId
+		  AND f.event_type = 'COMPLETE'
+		  AND DATE(f.occurred_at) = :date
+		LIMIT 1
+	""", nativeQuery = true)
+	Optional<FeedItem> findByParentAndChildComplete(
+		@Param("parentId") Long parentId,
+		@Param("childId") Long childId,
+		@Param("date") java.time.LocalDate date
+	);
+
 	@Modifying
 	@Query("DELETE FROM FeedItem f WHERE f.child.id = :childId")
 	void deleteAllByChildId(@Param("childId") Long childId);

--- a/src/main/java/com/kiero/feed/application/dto/FeedItemDto.java
+++ b/src/main/java/com/kiero/feed/application/dto/FeedItemDto.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.kiero.feed.domain.enums.EventType;
 
 public record FeedItemDto(
+	Long id,
 	EventType eventType,
 	@JsonFormat(pattern = "yyyy.MM.dd HH:mm")
 	LocalDateTime occurredAt,

--- a/src/main/java/com/kiero/feed/application/port/out/FeedItemQueryPort.java
+++ b/src/main/java/com/kiero/feed/application/port/out/FeedItemQueryPort.java
@@ -1,5 +1,6 @@
 package com.kiero.feed.application.port.out;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +23,12 @@ public interface FeedItemQueryPort {
 	List<Long> findUnreadItemIdsByParentIdAndChildId(Long parentId, Long childId);
 
 	Optional<FeedItem> findByParentIdAndScheduleDetailIdAndEventType(Long parentId, Long scheduleDetailId, EventType eventType);
+
+	Optional<FeedItem> findByParentIdAndMissionId(Long parentId, Long missionId);
+
+	Optional<FeedItem> findByParentIdAndCouponId(Long parentId, Long couponId);
+
+	Optional<FeedItem> findByParentAndChildComplete(Long parentId, Long childId, LocalDate date);
 
 	List<FeedItem> findUnreadFeedItem(Long parentId);
 }

--- a/src/main/java/com/kiero/feed/application/service/FeedQueryService.java
+++ b/src/main/java/com/kiero/feed/application/service/FeedQueryService.java
@@ -100,6 +100,7 @@ public class FeedQueryService implements FeedQueryUseCase {
 
 	private FeedItemDto toItemDto(FeedItem feedItem) {
 		return new FeedItemDto(
+			feedItem.getId(),
 			feedItem.getEventType(),
 			feedItem.getOccurredAt(),
 			feedItem.getMetadata()

--- a/src/main/java/com/kiero/global/notification/adapter/in/event/PushNotificationEventListener.java
+++ b/src/main/java/com/kiero/global/notification/adapter/in/event/PushNotificationEventListener.java
@@ -30,56 +30,56 @@ public class PushNotificationEventListener {
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(ScheduleVerifiedEvent event) {
 		for (Long parentId : event.parentIds()) {
-			String feedId = feedItemLookupPort.findFeedIdByParentAndScheduleDetail(parentId, event.scheduleDetailId())
+			String feedItemId = feedItemLookupPort.findFeedItemIdByParentAndScheduleDetail(parentId, event.scheduleDetailId())
 				.map(String::valueOf)
 				.orElseGet(() -> {
-					log.warn("feedId 조회 실패: type=SCHEDULE_VERIFIED, parentId={}, scheduleDetailId={}", parentId, event.scheduleDetailId());
+					log.warn("feedItemId 조회 실패: type=SCHEDULE_VERIFIED, parentId={}, scheduleDetailId={}", parentId, event.scheduleDetailId());
 					return "";
 				});
-			log.debug("푸시 알림 (일정 인증): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
-			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.SCHEDULE_VERIFIED, feedId, event.scheduleName());
+			log.debug("푸시 알림 (일정 인증): parentId={}, childId={}, feedItemId={}", parentId, event.childId(), feedItemId);
+			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.SCHEDULE_VERIFIED, feedItemId, event.scheduleName());
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(FireLitEvent event) {
 		for (Long parentId : event.parentIds()) {
-			String feedId = feedItemLookupPort.findFeedIdByParentAndChildComplete(parentId, event.childId(), event.occurredDate())
+			String feedItemId = feedItemLookupPort.findFeedItemIdByParentAndChildComplete(parentId, event.childId(), event.occurredDate())
 				.map(String::valueOf)
 				.orElseGet(() -> {
-					log.warn("feedId 조회 실패: type=FIRE_LIT, parentId={}, childId={}, date={}", parentId, event.childId(), event.occurredDate());
+					log.warn("feedItemId 조회 실패: type=FIRE_LIT, parentId={}, childId={}, date={}", parentId, event.childId(), event.occurredDate());
 					return "";
 				});
-			log.debug("푸시 알림 (불꽃 피우기): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
-			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.FIRE_LIT, feedId, "");
+			log.debug("푸시 알림 (불꽃 피우기): parentId={}, childId={}, feedItemId={}", parentId, event.childId(), feedItemId);
+			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.FIRE_LIT, feedItemId, "");
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(MissionCompleteEvent event) {
 		for (Long parentId : event.parentIds()) {
-			String feedId = feedItemLookupPort.findFeedIdByParentAndMission(parentId, event.missionId())
+			String feedItemId = feedItemLookupPort.findFeedItemIdByParentAndMission(parentId, event.missionId())
 				.map(String::valueOf)
 				.orElseGet(() -> {
-					log.warn("feedId 조회 실패: type=MISSION_COMPLETE, parentId={}, missionId={}", parentId, event.missionId());
+					log.warn("feedItemId 조회 실패: type=MISSION_COMPLETE, parentId={}, missionId={}", parentId, event.missionId());
 					return "";
 				});
-			log.debug("푸시 알림 (미션 완료): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
-			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.MISSION_COMPLETE, feedId, event.missionName());
+			log.debug("푸시 알림 (미션 완료): parentId={}, childId={}, feedItemId={}", parentId, event.childId(), feedItemId);
+			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.MISSION_COMPLETE, feedItemId, event.missionName());
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(CouponPurchasedEvent event) {
 		for (Long parentId : event.parentIds()) {
-			String feedId = feedItemLookupPort.findFeedIdByParentAndCoupon(parentId, event.couponId())
+			String feedItemId = feedItemLookupPort.findFeedItemIdByParentAndCoupon(parentId, event.couponId())
 				.map(String::valueOf)
 				.orElseGet(() -> {
-					log.warn("feedId 조회 실패: type=COUPON_PURCHASED, parentId={}, couponId={}", parentId, event.couponId());
+					log.warn("feedItemId 조회 실패: type=COUPON_PURCHASED, parentId={}, couponId={}", parentId, event.couponId());
 					return "";
 				});
-			log.debug("푸시 알림 (쿠폰 구매): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
-			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.COUPON_PURCHASED, feedId, event.couponName());
+			log.debug("푸시 알림 (쿠폰 구매): parentId={}, childId={}, feedItemId={}", parentId, event.childId(), feedItemId);
+			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.COUPON_PURCHASED, feedItemId, event.couponName());
 		}
 	}
 

--- a/src/main/java/com/kiero/global/notification/adapter/in/event/PushNotificationEventListener.java
+++ b/src/main/java/com/kiero/global/notification/adapter/in/event/PushNotificationEventListener.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.kiero.coupon.application.dto.CouponPurchasedEvent;
 import com.kiero.global.notification.application.port.in.PushNotificationUseCase;
+import com.kiero.global.notification.application.port.out.FeedItemLookupPort;
 import com.kiero.global.notification.domain.PushNotificationType;
 import com.kiero.mission.application.dto.MissionCompleteEvent;
 import com.kiero.schedule.application.dto.FireLitEvent;
@@ -24,37 +25,45 @@ import lombok.extern.slf4j.Slf4j;
 public class PushNotificationEventListener {
 
 	private final PushNotificationUseCase pushNotificationUseCase;
+	private final FeedItemLookupPort feedItemLookupPort;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(ScheduleVerifiedEvent event) {
-		String targetId = event.feedItemId() != null ? String.valueOf(event.feedItemId()) : "";
 		for (Long parentId : event.parentIds()) {
-			log.debug("푸시 알림 (일정 인증): parentId={}, childId={}", parentId, event.childId());
-			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.SCHEDULE_VERIFIED, targetId, event.scheduleName());
+			String feedId = feedItemLookupPort.findFeedIdByParentAndScheduleDetail(parentId, event.scheduleDetailId())
+				.map(String::valueOf).orElse("");
+			log.debug("푸시 알림 (일정 인증): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
+			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.SCHEDULE_VERIFIED, feedId, event.scheduleName());
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(FireLitEvent event) {
 		for (Long parentId : event.parentIds()) {
-			log.debug("푸시 알림 (불꽃 피우기): parentId={}, childId={}", parentId, event.childId());
-			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.FIRE_LIT, "", "");
+			String feedId = feedItemLookupPort.findFeedIdByParentAndChildComplete(parentId, event.childId(), event.occurredDate())
+				.map(String::valueOf).orElse("");
+			log.debug("푸시 알림 (불꽃 피우기): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
+			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.FIRE_LIT, feedId, "");
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(MissionCompleteEvent event) {
 		for (Long parentId : event.parentIds()) {
-			log.debug("푸시 알림 (미션 완료): parentId={}, childId={}", parentId, event.childId());
-			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.MISSION_COMPLETE, "", event.missionName());
+			String feedId = feedItemLookupPort.findFeedIdByParentAndMission(parentId, event.missionId())
+				.map(String::valueOf).orElse("");
+			log.debug("푸시 알림 (미션 완료): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
+			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.MISSION_COMPLETE, feedId, event.missionName());
 		}
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handle(CouponPurchasedEvent event) {
 		for (Long parentId : event.parentIds()) {
-			log.debug("푸시 알림 (쿠폰 구매): parentId={}, childId={}", parentId, event.childId());
-			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.COUPON_PURCHASED, "", event.couponName());
+			String feedId = feedItemLookupPort.findFeedIdByParentAndCoupon(parentId, event.couponId())
+				.map(String::valueOf).orElse("");
+			log.debug("푸시 알림 (쿠폰 구매): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
+			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.COUPON_PURCHASED, feedId, event.couponName());
 		}
 	}
 

--- a/src/main/java/com/kiero/global/notification/adapter/in/event/PushNotificationEventListener.java
+++ b/src/main/java/com/kiero/global/notification/adapter/in/event/PushNotificationEventListener.java
@@ -31,7 +31,11 @@ public class PushNotificationEventListener {
 	public void handle(ScheduleVerifiedEvent event) {
 		for (Long parentId : event.parentIds()) {
 			String feedId = feedItemLookupPort.findFeedIdByParentAndScheduleDetail(parentId, event.scheduleDetailId())
-				.map(String::valueOf).orElse("");
+				.map(String::valueOf)
+				.orElseGet(() -> {
+					log.warn("feedId 조회 실패: type=SCHEDULE_VERIFIED, parentId={}, scheduleDetailId={}", parentId, event.scheduleDetailId());
+					return "";
+				});
 			log.debug("푸시 알림 (일정 인증): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
 			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.SCHEDULE_VERIFIED, feedId, event.scheduleName());
 		}
@@ -41,7 +45,11 @@ public class PushNotificationEventListener {
 	public void handle(FireLitEvent event) {
 		for (Long parentId : event.parentIds()) {
 			String feedId = feedItemLookupPort.findFeedIdByParentAndChildComplete(parentId, event.childId(), event.occurredDate())
-				.map(String::valueOf).orElse("");
+				.map(String::valueOf)
+				.orElseGet(() -> {
+					log.warn("feedId 조회 실패: type=FIRE_LIT, parentId={}, childId={}, date={}", parentId, event.childId(), event.occurredDate());
+					return "";
+				});
 			log.debug("푸시 알림 (불꽃 피우기): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
 			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.FIRE_LIT, feedId, "");
 		}
@@ -51,7 +59,11 @@ public class PushNotificationEventListener {
 	public void handle(MissionCompleteEvent event) {
 		for (Long parentId : event.parentIds()) {
 			String feedId = feedItemLookupPort.findFeedIdByParentAndMission(parentId, event.missionId())
-				.map(String::valueOf).orElse("");
+				.map(String::valueOf)
+				.orElseGet(() -> {
+					log.warn("feedId 조회 실패: type=MISSION_COMPLETE, parentId={}, missionId={}", parentId, event.missionId());
+					return "";
+				});
 			log.debug("푸시 알림 (미션 완료): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
 			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.MISSION_COMPLETE, feedId, event.missionName());
 		}
@@ -61,7 +73,11 @@ public class PushNotificationEventListener {
 	public void handle(CouponPurchasedEvent event) {
 		for (Long parentId : event.parentIds()) {
 			String feedId = feedItemLookupPort.findFeedIdByParentAndCoupon(parentId, event.couponId())
-				.map(String::valueOf).orElse("");
+				.map(String::valueOf)
+				.orElseGet(() -> {
+					log.warn("feedId 조회 실패: type=COUPON_PURCHASED, parentId={}, couponId={}", parentId, event.couponId());
+					return "";
+				});
 			log.debug("푸시 알림 (쿠폰 구매): parentId={}, childId={}, feedId={}", parentId, event.childId(), feedId);
 			pushNotificationUseCase.pushToParent(parentId, event.childId(), PushNotificationType.COUPON_PURCHASED, feedId, event.couponName());
 		}

--- a/src/main/java/com/kiero/global/notification/adapter/out/feed/FeedItemLookupAdapter.java
+++ b/src/main/java/com/kiero/global/notification/adapter/out/feed/FeedItemLookupAdapter.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 
-import com.kiero.feed.adapter.out.persistence.FeedItemRepository;
+import com.kiero.feed.application.port.out.FeedItemQueryPort;
 import com.kiero.feed.domain.enums.EventType;
 import com.kiero.global.notification.application.port.out.FeedItemLookupPort;
 
@@ -15,30 +15,29 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FeedItemLookupAdapter implements FeedItemLookupPort {
 
-	private final FeedItemRepository feedItemRepository;
+	private final FeedItemQueryPort feedItemQueryPort;
 
 	@Override
 	public Optional<Long> findFeedItemIdByParentAndScheduleDetail(Long parentId, Long scheduleDetailId) {
-		return feedItemRepository.findByParentIdAndScheduleDetailIdAndEventType(
-				parentId, String.valueOf(scheduleDetailId), EventType.SCHEDULE.name())
+		return feedItemQueryPort.findByParentIdAndScheduleDetailIdAndEventType(parentId, scheduleDetailId, EventType.SCHEDULE)
 			.map(fi -> fi.getId());
 	}
 
 	@Override
 	public Optional<Long> findFeedItemIdByParentAndMission(Long parentId, Long missionId) {
-		return feedItemRepository.findByParentIdAndMissionId(parentId, String.valueOf(missionId))
+		return feedItemQueryPort.findByParentIdAndMissionId(parentId, missionId)
 			.map(fi -> fi.getId());
 	}
 
 	@Override
 	public Optional<Long> findFeedItemIdByParentAndCoupon(Long parentId, Long couponId) {
-		return feedItemRepository.findByParentIdAndCouponId(parentId, String.valueOf(couponId))
+		return feedItemQueryPort.findByParentIdAndCouponId(parentId, couponId)
 			.map(fi -> fi.getId());
 	}
 
 	@Override
 	public Optional<Long> findFeedItemIdByParentAndChildComplete(Long parentId, Long childId, LocalDate date) {
-		return feedItemRepository.findByParentAndChildComplete(parentId, childId, date)
+		return feedItemQueryPort.findByParentAndChildComplete(parentId, childId, date)
 			.map(fi -> fi.getId());
 	}
 }

--- a/src/main/java/com/kiero/global/notification/adapter/out/feed/FeedItemLookupAdapter.java
+++ b/src/main/java/com/kiero/global/notification/adapter/out/feed/FeedItemLookupAdapter.java
@@ -18,26 +18,26 @@ public class FeedItemLookupAdapter implements FeedItemLookupPort {
 	private final FeedItemRepository feedItemRepository;
 
 	@Override
-	public Optional<Long> findFeedIdByParentAndScheduleDetail(Long parentId, Long scheduleDetailId) {
+	public Optional<Long> findFeedItemIdByParentAndScheduleDetail(Long parentId, Long scheduleDetailId) {
 		return feedItemRepository.findByParentIdAndScheduleDetailIdAndEventType(
 				parentId, String.valueOf(scheduleDetailId), EventType.SCHEDULE.name())
 			.map(fi -> fi.getId());
 	}
 
 	@Override
-	public Optional<Long> findFeedIdByParentAndMission(Long parentId, Long missionId) {
+	public Optional<Long> findFeedItemIdByParentAndMission(Long parentId, Long missionId) {
 		return feedItemRepository.findByParentIdAndMissionId(parentId, String.valueOf(missionId))
 			.map(fi -> fi.getId());
 	}
 
 	@Override
-	public Optional<Long> findFeedIdByParentAndCoupon(Long parentId, Long couponId) {
+	public Optional<Long> findFeedItemIdByParentAndCoupon(Long parentId, Long couponId) {
 		return feedItemRepository.findByParentIdAndCouponId(parentId, String.valueOf(couponId))
 			.map(fi -> fi.getId());
 	}
 
 	@Override
-	public Optional<Long> findFeedIdByParentAndChildComplete(Long parentId, Long childId, LocalDate date) {
+	public Optional<Long> findFeedItemIdByParentAndChildComplete(Long parentId, Long childId, LocalDate date) {
 		return feedItemRepository.findByParentAndChildComplete(parentId, childId, date)
 			.map(fi -> fi.getId());
 	}

--- a/src/main/java/com/kiero/global/notification/adapter/out/feed/FeedItemLookupAdapter.java
+++ b/src/main/java/com/kiero/global/notification/adapter/out/feed/FeedItemLookupAdapter.java
@@ -1,0 +1,44 @@
+package com.kiero.global.notification.adapter.out.feed;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.feed.adapter.out.persistence.FeedItemRepository;
+import com.kiero.feed.domain.enums.EventType;
+import com.kiero.global.notification.application.port.out.FeedItemLookupPort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class FeedItemLookupAdapter implements FeedItemLookupPort {
+
+	private final FeedItemRepository feedItemRepository;
+
+	@Override
+	public Optional<Long> findFeedIdByParentAndScheduleDetail(Long parentId, Long scheduleDetailId) {
+		return feedItemRepository.findByParentIdAndScheduleDetailIdAndEventType(
+				parentId, String.valueOf(scheduleDetailId), EventType.SCHEDULE.name())
+			.map(fi -> fi.getId());
+	}
+
+	@Override
+	public Optional<Long> findFeedIdByParentAndMission(Long parentId, Long missionId) {
+		return feedItemRepository.findByParentIdAndMissionId(parentId, String.valueOf(missionId))
+			.map(fi -> fi.getId());
+	}
+
+	@Override
+	public Optional<Long> findFeedIdByParentAndCoupon(Long parentId, Long couponId) {
+		return feedItemRepository.findByParentIdAndCouponId(parentId, String.valueOf(couponId))
+			.map(fi -> fi.getId());
+	}
+
+	@Override
+	public Optional<Long> findFeedIdByParentAndChildComplete(Long parentId, Long childId, LocalDate date) {
+		return feedItemRepository.findByParentAndChildComplete(parentId, childId, date)
+			.map(fi -> fi.getId());
+	}
+}

--- a/src/main/java/com/kiero/global/notification/application/port/out/FeedItemLookupPort.java
+++ b/src/main/java/com/kiero/global/notification/application/port/out/FeedItemLookupPort.java
@@ -4,8 +4,8 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 public interface FeedItemLookupPort {
-	Optional<Long> findFeedIdByParentAndScheduleDetail(Long parentId, Long scheduleDetailId);
-	Optional<Long> findFeedIdByParentAndMission(Long parentId, Long missionId);
-	Optional<Long> findFeedIdByParentAndCoupon(Long parentId, Long couponId);
-	Optional<Long> findFeedIdByParentAndChildComplete(Long parentId, Long childId, LocalDate date);
+	Optional<Long> findFeedItemIdByParentAndScheduleDetail(Long parentId, Long scheduleDetailId);
+	Optional<Long> findFeedItemIdByParentAndMission(Long parentId, Long missionId);
+	Optional<Long> findFeedItemIdByParentAndCoupon(Long parentId, Long couponId);
+	Optional<Long> findFeedItemIdByParentAndChildComplete(Long parentId, Long childId, LocalDate date);
 }

--- a/src/main/java/com/kiero/global/notification/application/port/out/FeedItemLookupPort.java
+++ b/src/main/java/com/kiero/global/notification/application/port/out/FeedItemLookupPort.java
@@ -1,0 +1,11 @@
+package com.kiero.global.notification.application.port.out;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface FeedItemLookupPort {
+	Optional<Long> findFeedIdByParentAndScheduleDetail(Long parentId, Long scheduleDetailId);
+	Optional<Long> findFeedIdByParentAndMission(Long parentId, Long missionId);
+	Optional<Long> findFeedIdByParentAndCoupon(Long parentId, Long couponId);
+	Optional<Long> findFeedIdByParentAndChildComplete(Long parentId, Long childId, LocalDate date);
+}

--- a/src/main/java/com/kiero/mission/application/dto/MissionCompleteEvent.java
+++ b/src/main/java/com/kiero/mission/application/dto/MissionCompleteEvent.java
@@ -5,6 +5,7 @@ import java.util.List;
 public record MissionCompleteEvent(
 	List<Long> parentIds,
 	Long childId,
+	Long missionId,
 	String missionName
 ) {
 }

--- a/src/main/java/com/kiero/mission/application/service/MissionCommandService.java
+++ b/src/main/java/com/kiero/mission/application/service/MissionCommandService.java
@@ -152,7 +152,7 @@ public class MissionCommandService implements MissionCommandUseCase {
 			LocalDateTime.now()
 		));
 
-		eventPort.publish(new MissionCompleteEvent(parentIds, childId, mission.getName()));
+		eventPort.publish(new MissionCompleteEvent(parentIds, childId, mission.getId(), mission.getName()));
 
 		missionCacheEvictHelper.evictByChildId(childId);
 

--- a/src/main/java/com/kiero/schedule/application/dto/FireLitEvent.java
+++ b/src/main/java/com/kiero/schedule/application/dto/FireLitEvent.java
@@ -1,9 +1,11 @@
 package com.kiero.schedule.application.dto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public record FireLitEvent(
 	List<Long> parentIds,
-	Long childId
+	Long childId,
+	LocalDate occurredDate
 ) {
 }

--- a/src/main/java/com/kiero/schedule/application/dto/ScheduleVerifiedEvent.java
+++ b/src/main/java/com/kiero/schedule/application/dto/ScheduleVerifiedEvent.java
@@ -5,7 +5,7 @@ import java.util.List;
 public record ScheduleVerifiedEvent(
 	List<Long> parentIds,
 	Long childId,
-	Long feedItemId,
+	Long scheduleDetailId,
 	String scheduleName
 ) {
 }

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -303,7 +303,7 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			.map(Parent::getId)
 			.toList();
 
-		scheduleEventPort.publish(new FireLitEvent(parentIds, child.getId()));
+		scheduleEventPort.publish(new FireLitEvent(parentIds, child.getId(), LocalDate.now(clock)));
 		scheduleEventPort.publish(new FireLitEventForFeed(parents, child.getId(), earnedCoinAmount, LocalDateTime.now(clock)));
 		return FireLitResponse.of(gotStones, earnedCoinAmount);
 	}

--- a/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
+++ b/src/main/java/com/kiero/schedule/application/service/ScheduleCommandService.java
@@ -303,8 +303,8 @@ public class ScheduleCommandService implements ScheduleCommandUseCase {
 			.map(Parent::getId)
 			.toList();
 
-		scheduleEventPort.publish(new FireLitEvent(parentIds, child.getId(), LocalDate.now(clock)));
-		scheduleEventPort.publish(new FireLitEventForFeed(parents, child.getId(), earnedCoinAmount, LocalDateTime.now(clock)));
+		scheduleEventPort.publish(new FireLitEventForFeed(parents, child.getId(), earnedCoinAmount, now));
+		scheduleEventPort.publish(new FireLitEvent(parentIds, child.getId(), now.toLocalDate()));
 		return FireLitResponse.of(gotStones, earnedCoinAmount);
 	}
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #254 

## Work Description ✏️

- 부모의 푸시 알림 수신 이벤트 중, 아래와 같은 상황에서 푸시 페이로드의 targetId로 매칭되는 이벤트 피드의 id를 전달합니다.
  - 미션 완료
  - 쿠폰 구매
  - 불피우기
  - 일정 인증
- 추가로, 클라이언트측에서 해당하는 피드를 최상단에 배치시키기 위해, 기존 피드 조회 API에 feed의 ID필드를 추가로 전달합니다.
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->
### 피드 조회 API
<img width="1286" height="779" alt="image" src="https://github.com/user-attachments/assets/ebeacc44-770d-4c5a-adb9-ea0937e70787" />

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이벤트에 항목 식별자(쿠폰/미션/스케줄 날짜 등)와 피드 항목 ID가 포함되어 더 구체적인 활동 정보가 전달됩니다.

* **개선사항**
  * 푸시 알림과 피드 연동 로직을 강화해 알림에 관련 피드 항목이 정확히 연결되며, 활동 이력 조회와 알림 전달 신뢰성이 향상되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-Kiero/Kiero-Server/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->