### PR TITLE
[fix] #256 - 아이 삭제 시 연관된 couponHistory를 삭제하도록 변경

### DIFF
--- a/src/main/java/com/kiero/admin/adapter/out/persistence/AdminDeleteAdapter.java
+++ b/src/main/java/com/kiero/admin/adapter/out/persistence/AdminDeleteAdapter.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import com.kiero.admin.application.port.out.AdminDeletePort;
 import com.kiero.child.adapter.out.persistence.ChildRepository;
+import com.kiero.coupon.adapter.out.persistence.CouponHistoryRepository;
 import com.kiero.coupon.adapter.out.persistence.CouponRepository;
 import com.kiero.feed.adapter.out.persistence.FeedItemRepository;
 import com.kiero.mission.adapter.out.persistence.MissionRepository;
@@ -29,6 +30,7 @@ public class AdminDeleteAdapter implements AdminDeletePort {
 	private final ScheduleRepeatDaysRepository scheduleRepeatDaysRepository;
 	private final MissionRepository missionRepository;
 	private final CouponRepository couponRepository;
+	private final CouponHistoryRepository couponHistoryRepository;
 	private final FeedItemRepository feedItemRepository;
 	private final ParentChildRepository parentChildRepository;
 	private final ChildRepository childRepository;
@@ -48,6 +50,11 @@ public class AdminDeleteAdapter implements AdminDeletePort {
 	@Override
 	public void deleteAllCouponsByChildId(Long childId) {
 		couponRepository.deleteAllByChildId(childId);
+	}
+
+	@Override
+	public void deleteAllCouponHistoriesByChildId(Long childId) {
+		couponHistoryRepository.deleteAllByChildId(childId);
 	}
 
 	@Override

--- a/src/main/java/com/kiero/admin/application/port/out/AdminDeletePort.java
+++ b/src/main/java/com/kiero/admin/application/port/out/AdminDeletePort.java
@@ -6,6 +6,7 @@ public interface AdminDeletePort {
 	void deleteAllSchedulesByChildId(Long childId);
 	void deleteAllMissionsByChildId(Long childId);
 	void deleteAllCouponsByChildId(Long childId);
+	void deleteAllCouponHistoriesByChildId(Long childId);
 	void deleteAllFeedItemsByChildId(Long childId);
 	void deleteAllParentChildRelationsByChildId(Long childId);
 	void deleteChild(Long childId);

--- a/src/main/java/com/kiero/admin/application/service/AdminUserCommandService.java
+++ b/src/main/java/com/kiero/admin/application/service/AdminUserCommandService.java
@@ -43,6 +43,7 @@ public class AdminUserCommandService implements AdminUserCommandUseCase {
 		adminDeletePort.deleteAllSchedulesByChildId(childId);
 		adminDeletePort.deleteAllMissionsByChildId(childId);
 		adminDeletePort.deleteAllCouponsByChildId(childId);
+		adminDeletePort.deleteAllCouponHistoriesByChildId(childId);
 		adminDeletePort.deleteAllFeedItemsByChildId(childId);
 		adminDeletePort.deleteAllParentChildRelationsByChildId(childId);
 		adminDeletePort.deleteChild(childId);

--- a/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponHistoryPersistenceAdapter.java
+++ b/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponHistoryPersistenceAdapter.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.kiero.coupon.application.port.out.CouponHistoryDeletePort;
 import com.kiero.coupon.application.port.out.CouponHistoryPersistencePort;
 import com.kiero.coupon.domain.CouponHistory;
 
@@ -11,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class CouponHistoryPersistenceAdapter implements CouponHistoryPersistencePort {
+public class CouponHistoryPersistenceAdapter implements CouponHistoryPersistencePort, CouponHistoryDeletePort {
 
 	private final CouponHistoryRepository couponHistoryRepository;
 
@@ -23,5 +24,10 @@ public class CouponHistoryPersistenceAdapter implements CouponHistoryPersistence
 	@Override
 	public List<CouponHistory> findAllByChildIdCreatedAtDesc(Long childId) {
 		return couponHistoryRepository.findAllByChildIdOrderByCreatedAtDesc(childId);
+	}
+
+	@Override
+	public void deleteAllByChildId(Long childId) {
+		couponHistoryRepository.deleteAllByChildId(childId);
 	}
 }

--- a/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponHistoryRepository.java
+++ b/src/main/java/com/kiero/coupon/adapter/out/persistence/CouponHistoryRepository.java
@@ -3,6 +3,9 @@ package com.kiero.coupon.adapter.out.persistence;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.kiero.coupon.domain.CouponHistory;
@@ -10,4 +13,8 @@ import com.kiero.coupon.domain.CouponHistory;
 @Repository
 public interface CouponHistoryRepository extends JpaRepository<CouponHistory, Long> {
 	List<CouponHistory> findAllByChildIdOrderByCreatedAtDesc(Long childId);
+
+	@Modifying
+	@Query("DELETE FROM CouponHistory ch WHERE ch.child.id = :childId")
+	void deleteAllByChildId(@Param("childId") Long childId);
 }

--- a/src/main/java/com/kiero/coupon/application/port/out/CouponHistoryDeletePort.java
+++ b/src/main/java/com/kiero/coupon/application/port/out/CouponHistoryDeletePort.java
@@ -1,0 +1,5 @@
+package com.kiero.coupon.application.port.out;
+
+public interface CouponHistoryDeletePort {
+	void deleteAllByChildId(Long childId);
+}

--- a/src/main/java/com/kiero/parent/application/service/ParentWithdrawService.java
+++ b/src/main/java/com/kiero/parent/application/service/ParentWithdrawService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.kiero.child.application.port.out.ChildDeletePort;
 import com.kiero.coupon.application.port.out.CouponDeletePort;
+import com.kiero.coupon.application.port.out.CouponHistoryDeletePort;
 import com.kiero.coupon.application.port.out.CouponTransferPort;
 import com.kiero.feed.application.port.out.FeedItemDeletePort;
 import com.kiero.feed.application.port.out.FeedItemTransferPort;
@@ -52,6 +53,7 @@ public class ParentWithdrawService implements ParentWithdrawUseCase {
 	private final MissionDeletePort missionDeletePort;
 	private final MissionTransferPort missionTransferPort;
 	private final CouponDeletePort couponDeletePort;
+	private final CouponHistoryDeletePort couponHistoryDeletePort;
 	private final CouponTransferPort couponTransferPort;
 	private final FeedItemDeletePort feedItemDeletePort;
 	private final FeedItemTransferPort feedItemTransferPort;
@@ -59,7 +61,6 @@ public class ParentWithdrawService implements ParentWithdrawUseCase {
 	private final ChildDeletePort childDeletePort;
 
 	@Override
-	@Transactional
 	public void withdraw(Long parentId) {
 		Parent parent = parentLoadPort.findById(parentId)
 			.orElseThrow(() -> new KieroException(ParentErrorCode.PARENT_NOT_FOUND));
@@ -112,6 +113,7 @@ public class ParentWithdrawService implements ParentWithdrawUseCase {
 			missionDeletePort.deleteAllByChildId(childId);
 			couponDeletePort.deleteAllByChildId(childId);
 			feedItemDeletePort.deleteAllByChildId(childId);
+			couponHistoryDeletePort.deleteAllByChildId(childId);
 
 			parentWithdrawEventPort.publish(new ParentWithdrawnEvent(childId));
 			parentWithdrawNotificationPort.storeWithdrawalMarker(childId);


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #256

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
아이의 유일한 부모가 탈퇴 시 아이의 정보도 함께 삭제되는데, couponHistory 삭제를 누락해 부모의 탈퇴 로직이 제대로 작동하지 않던 이슈를 해결하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 자식 계정 삭제 시 관련 쿠폰 히스토리가 함께 정리됩니다.
  * 부모 계정 탈퇴 시 자녀의 쿠폰 히스토리가 정리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->