### PR TITLE
[fix] #261 - 마지막 일정의 종료 시간이 지나지 않은 상태에서 일정을 인증하였을 경우, NOW_SCHEDULE_EX…

### DIFF
--- a/src/main/java/com/kiero/schedule/application/service/resolver/TodayScheduleStatusResolver.java
+++ b/src/main/java/com/kiero/schedule/application/service/resolver/TodayScheduleStatusResolver.java
@@ -38,6 +38,22 @@ public final class TodayScheduleStatusResolver {
 				// 모든 일정을 스킵하거나 실패해서 얻은 불조각 수가 0개일 때
 				if (earnedStones == 0) { return TodayScheduleStatus.NO_SCHEDULE; }
 
+				// 마지막 완료 일정의 시간 내에 현재 시각이 있으면 아직 진행 중으로 처리
+				LocalTime now = LocalTime.now();
+				ScheduleDetail lastCompleted = filteredAllScheduleDetails.stream()
+					.filter(sd -> sd.getScheduleStatus() != ScheduleStatus.PENDING
+						&& sd.getScheduleStatus() != ScheduleStatus.SKIPPED)
+					.reduce((a, b) -> b)
+					.orElse(null);
+
+				if (lastCompleted != null) {
+					LocalTime start = lastCompleted.getSchedule().getStartTime();
+					LocalTime end = lastCompleted.getSchedule().getEndTime();
+					if (!now.isBefore(start) && now.isBefore(end)) {
+						return TodayScheduleStatus.NOW_SCHEDULE_EXIST;
+					}
+				}
+
 				return TodayScheduleStatus.FIRE_NOT_LIT;
 			}
 


### PR DESCRIPTION
…ISTS를 반환

## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #261

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
이번 기획사항 변경으로, 마지막 일정의 종료시간이 지나지 않은 상태에서 일정을 인증하였을 경우, NOW_SCHEDULE_EXISTS를 반환하여 클라의 분기처리를 유도하여야 합니다. 기존에는 FIRE_NOT_LIT을 반환하고 있었습니다. 

스킵된 일정(SKIPPED), 대기중인 일정(PENDING)을 필터링한 후, 오늘의 제일 마지막 일정을 추출하고, 일정의 시작-종료시간과 현재의 시간을 비교하여 올바른 status를 반환하도록 수정하였습니다.  

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

### 마지막 일정 인증 완료, 아직 시간이 지나지 않음
<img width="867" height="587" alt="image" src="https://github.com/user-attachments/assets/8fc40896-ba99-4aca-9a45-9827d5dec860" />

### 마지막 일정 인증 완료, 시간이 지남
<img width="850" height="624" alt="image" src="https://github.com/user-attachments/assets/2aa402aa-30dc-4305-89ec-2dba5e0a4ef3" />


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 현재 진행 중인 일정을 정확하게 감지하는 로직을 개선했습니다. 이제 시스템이 현재 시각이 일정의 시간 범위 내에 있는지 올바르게 판단합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->