### PR TITLE
[fix] #265 - 마지막 일정을 인증하고 넘어갔을 때 FIRE_NOT_LIT status가 반환되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/kiero/schedule/application/service/resolver/TodayScheduleStatusResolver.java
+++ b/src/main/java/com/kiero/schedule/application/service/resolver/TodayScheduleStatusResolver.java
@@ -42,7 +42,7 @@ public final class TodayScheduleStatusResolver {
 				LocalTime now = LocalTime.now();
 				ScheduleDetail lastCompleted = filteredAllScheduleDetails.stream()
 					.filter(sd -> sd.getScheduleStatus() != ScheduleStatus.PENDING
-						&& sd.getScheduleStatus() != ScheduleStatus.SKIPPED)
+						&& sd.getScheduleStatus() != ScheduleStatus.SKIPPED && sd.getScheduleStatus() != ScheduleStatus.COMPLETED)
 					.reduce((a, b) -> b)
 					.orElse(null);
 


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #265

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
리졸버에서 필터링이 누락되어 FIRE_NOT_LIT을 반환해야하는 상황에서 NOW_SCHEDULE_EXISTS를 반환하고 있던 문제를 해결하였습니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 일정 상태 판정 로직 개선으로 "마지막 완료 일정"을 더 정확하게 식별하도록 수정했습니다. 이에 따라 현재 시간 기반 일정 상태 판정이 더욱 정확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->