### PR TITLE
[feat] #267 - 애플 정책에 따른 계정 변경사항 이벤트 수집 API 추가

### DIFF
--- a/lambda/notification/index.js
+++ b/lambda/notification/index.js
@@ -25,8 +25,14 @@ exports.handler = async (event) => {
         body: JSON.stringify({
           message: {
             token: fcmToken,
-            notification: { title, body },
-            data: data ?? {},
+            data: {
+              title,
+              body,
+              ...(data ?? {}),
+            },
+            android: {
+              priority: 'high',
+            },
           },
         }),
       });

--- a/lambda/notification/index.js
+++ b/lambda/notification/index.js
@@ -38,6 +38,12 @@ exports.handler = async (event) => {
                 'apns-push-type': 'alert',
                 'apns-priority': '10',
               },
+              payload: {
+                aps: {
+                  alert: { title, body },
+                  sound: 'default',
+                },
+              },
             },
           },
         }),
@@ -52,12 +58,18 @@ exports.handler = async (event) => {
             ? `${fcmToken.slice(0, 4)}...${fcmToken.slice(-4)}`
             : '****';
 
+        const fieldViolations =
+          json.error?.details?.find((d) => d.fieldViolations)?.fieldViolations ?? [];
+        const isTokenFieldViolation = fieldViolations.some(
+          (v) => v.field === 'message.token' || /registration token/i.test(v.description ?? '')
+        );
+
         const isInvalidToken =
           errorCode === 'UNREGISTERED' ||
           (errorCode === 'INVALID_ARGUMENT' &&
-            /registration token|not a valid fcm registration token/i.test(
+            (/registration token|not a valid fcm registration token/i.test(
               json.error?.message ?? ''
-            ));
+            ) || isTokenFieldViolation));
 
         if (isInvalidToken) {
           console.warn(`FCM 토큰 무효 (스킵): ${maskedToken}, errorCode: ${errorCode}`);

--- a/lambda/notification/index.js
+++ b/lambda/notification/index.js
@@ -33,6 +33,12 @@ exports.handler = async (event) => {
             android: {
               priority: 'high',
             },
+            apns: {
+              headers: {
+                'apns-push-type': 'alert',
+                'apns-priority': '10',
+              },
+            },
           },
         }),
       });

--- a/src/main/java/com/kiero/global/auth/client/apple/AppleEventJwtParser.java
+++ b/src/main/java/com/kiero/global/auth/client/apple/AppleEventJwtParser.java
@@ -1,0 +1,132 @@
+package com.kiero.global.auth.client.apple;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kiero.global.auth.client.apple.dto.ApplePublicKeyResponse;
+import com.kiero.global.auth.client.apple.dto.AppleServerEvent;
+import com.kiero.global.auth.client.exception.OAuthErrorCode;
+import com.kiero.global.exception.KieroException;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleEventJwtParser {
+
+	private static final String APPLE_ISS = "https://appleid.apple.com";
+
+	@Value("${apple.team-id}")
+	private String teamId;
+
+	private final ApplePublicKeyProvider applePublicKeyProvider;
+	private final ObjectMapper objectMapper;
+
+	public AppleServerEvent parseAndVerify(String eventJwt) {
+		try {
+			String kid = extractKid(eventJwt);
+			ApplePublicKeyResponse.Key matchingKey = findMatchingKey(kid);
+			PublicKey publicKey = buildPublicKey(matchingKey);
+
+			Claims claims = Jwts.parserBuilder()
+				.setSigningKey(publicKey)
+				.build()
+				.parseClaimsJws(eventJwt)
+				.getBody();
+
+			validateClaims(claims);
+
+			String eventsJson = claims.get("events", String.class);
+			return objectMapper.readValue(eventsJson, AppleServerEvent.class);
+
+		} catch (KieroException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error("Apple event token 검증 실패: {}", e.getMessage());
+			throw new KieroException(OAuthErrorCode.INVALID_APPLE_EVENT_TOKEN);
+		}
+	}
+
+	private ApplePublicKeyResponse.Key findMatchingKey(String kid) {
+		Optional<ApplePublicKeyResponse.Key> key = applePublicKeyProvider.getPublicKeys().keys().stream()
+			.filter(k -> k.kid().equals(kid))
+			.findFirst();
+
+		if (key.isPresent()) {
+			return key.get();
+		}
+
+		log.info("캐시된 Apple public key에서 kid를 찾지 못했습니다. 캐시를 갱신합니다. kid: {}", kid);
+		applePublicKeyProvider.evictCache();
+
+		return applePublicKeyProvider.getPublicKeys().keys().stream()
+			.filter(k -> k.kid().equals(kid))
+			.findFirst()
+			.orElseThrow(() -> {
+				log.error("일치하는 Apple public key를 찾을 수 없습니다. kid: {}", kid);
+				return new KieroException(OAuthErrorCode.INVALID_APPLE_EVENT_TOKEN);
+			});
+	}
+
+	@SuppressWarnings("unchecked")
+	private String extractKid(String jwtToken) {
+		try {
+			String[] parts = jwtToken.split("\\.");
+			if (parts.length < 2) {
+				throw new KieroException(OAuthErrorCode.INVALID_APPLE_EVENT_TOKEN);
+			}
+			byte[] headerBytes = Base64.getUrlDecoder().decode(parts[0]);
+			Map<String, String> header = objectMapper.readValue(headerBytes, Map.class);
+			String kid = header.get("kid");
+			if (kid == null || kid.isBlank()) {
+				throw new KieroException(OAuthErrorCode.INVALID_APPLE_EVENT_TOKEN);
+			}
+			return kid;
+		} catch (KieroException e) {
+			throw e;
+		} catch (Exception e) {
+			log.error("Apple event token 헤더 파싱 실패: {}", e.getMessage());
+			throw new KieroException(OAuthErrorCode.INVALID_APPLE_EVENT_TOKEN);
+		}
+	}
+
+	private PublicKey buildPublicKey(ApplePublicKeyResponse.Key key) {
+		try {
+			byte[] nBytes = Base64.getUrlDecoder().decode(key.n());
+			byte[] eBytes = Base64.getUrlDecoder().decode(key.e());
+			RSAPublicKeySpec spec = new RSAPublicKeySpec(
+				new BigInteger(1, nBytes),
+				new BigInteger(1, eBytes)
+			);
+			return KeyFactory.getInstance("RSA").generatePublic(spec);
+		} catch (Exception e) {
+			log.error("Apple public key 생성 실패: {}", e.getMessage());
+			throw new KieroException(OAuthErrorCode.INVALID_APPLE_EVENT_TOKEN);
+		}
+	}
+
+	private void validateClaims(Claims claims) {
+		if (!APPLE_ISS.equals(claims.getIssuer())) {
+			log.error("Apple event token issuer 불일치: {}", claims.getIssuer());
+			throw new KieroException(OAuthErrorCode.INVALID_APPLE_EVENT_TOKEN);
+		}
+		// identityToken은 aud=bundle-id이지만, event token은 aud=team-id
+		if (!teamId.equals(claims.getAudience())) {
+			log.error("Apple event token audience 불일치: {}", claims.getAudience());
+			throw new KieroException(OAuthErrorCode.INVALID_APPLE_EVENT_TOKEN);
+		}
+	}
+}

--- a/src/main/java/com/kiero/global/auth/client/apple/AppleEventType.java
+++ b/src/main/java/com/kiero/global/auth/client/apple/AppleEventType.java
@@ -1,0 +1,31 @@
+package com.kiero.global.auth.client.apple;
+
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AppleEventType {
+	EMAIL_ENABLED("email-enabled"),
+	EMAIL_DISABLED("email-disabled"),
+	CONSENT_REVOKED("consent-revoked"),
+	ACCOUNT_DELETE("account-delete"),
+	UNKNOWN(null);
+
+	private final String value;
+
+	@JsonCreator
+	public static AppleEventType from(String value) {
+		if (value == null) {
+			return UNKNOWN;
+		}
+		return Arrays.stream(values())
+			.filter(t -> t.value != null && t.value.equals(value))
+			.findFirst()
+			.orElse(UNKNOWN);
+	}
+}

--- a/src/main/java/com/kiero/global/auth/client/apple/dto/AppleServerEvent.java
+++ b/src/main/java/com/kiero/global/auth/client/apple/dto/AppleServerEvent.java
@@ -1,0 +1,11 @@
+package com.kiero.global.auth.client.apple.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kiero.global.auth.client.apple.AppleEventType;
+
+public record AppleServerEvent(
+	AppleEventType type,
+	String sub,
+	@JsonProperty("event_time") long eventTime
+) {
+}

--- a/src/main/java/com/kiero/global/auth/client/exception/OAuthErrorCode.java
+++ b/src/main/java/com/kiero/global/auth/client/exception/OAuthErrorCode.java
@@ -19,6 +19,7 @@ public enum OAuthErrorCode implements BaseCode {
 	INVALID_APPLE_ID_TOKEN(HttpStatus.UNAUTHORIZED, "Apple identity token 검증에 실패했습니다."),
 	APPLE_CLIENT_SECRET_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Apple client secret 생성에 실패했습니다."),
 	APPLE_AUTH_CODE_EXCHANGE_FAILED(HttpStatus.UNAUTHORIZED, "Apple authorization code 교환에 실패했습니다."),
+	INVALID_APPLE_EVENT_TOKEN(HttpStatus.UNAUTHORIZED, "Apple 서버 이벤트 token 검증에 실패했습니다."),
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/kiero/global/config/SecurityConfig.java
+++ b/src/main/java/com/kiero/global/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
 					"/api/v1/children/login/**",
 					"/api/v1/tokens/reissue/*",
 					"/api/v1/tokens/subscribe-token",
-					"/api/v1/admin/login"
+					"/api/v1/admin/login",
+					"/api/v1/apple/events"
 				).permitAll()
 
 				.requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()

--- a/src/main/java/com/kiero/parent/adapter/in/web/AppleEventController.java
+++ b/src/main/java/com/kiero/parent/adapter/in/web/AppleEventController.java
@@ -1,0 +1,29 @@
+package com.kiero.parent.adapter.in.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kiero.parent.application.port.in.AppleEventUseCase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/apple")
+public class AppleEventController {
+
+	private final AppleEventUseCase appleEventUseCase;
+
+	@PostMapping("/events")
+	public ResponseEntity<Void> handleEvent(
+		@RequestParam("payload") String payload
+	) {
+		appleEventUseCase.handle(payload);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/kiero/parent/adapter/out/social/AppleEventParserAdapter.java
+++ b/src/main/java/com/kiero/parent/adapter/out/social/AppleEventParserAdapter.java
@@ -1,0 +1,21 @@
+package com.kiero.parent.adapter.out.social;
+
+import org.springframework.stereotype.Component;
+
+import com.kiero.global.auth.client.apple.AppleEventJwtParser;
+import com.kiero.global.auth.client.apple.dto.AppleServerEvent;
+import com.kiero.parent.application.port.out.AppleEventParsePort;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AppleEventParserAdapter implements AppleEventParsePort {
+
+	private final AppleEventJwtParser appleEventJwtParser;
+
+	@Override
+	public AppleServerEvent parse(String eventJwt) {
+		return appleEventJwtParser.parseAndVerify(eventJwt);
+	}
+}

--- a/src/main/java/com/kiero/parent/application/port/in/AppleEventUseCase.java
+++ b/src/main/java/com/kiero/parent/application/port/in/AppleEventUseCase.java
@@ -1,0 +1,5 @@
+package com.kiero.parent.application.port.in;
+
+public interface AppleEventUseCase {
+	void handle(String eventJwt);
+}

--- a/src/main/java/com/kiero/parent/application/port/out/AppleEventParsePort.java
+++ b/src/main/java/com/kiero/parent/application/port/out/AppleEventParsePort.java
@@ -1,0 +1,7 @@
+package com.kiero.parent.application.port.out;
+
+import com.kiero.global.auth.client.apple.dto.AppleServerEvent;
+
+public interface AppleEventParsePort {
+	AppleServerEvent parse(String eventJwt);
+}

--- a/src/main/java/com/kiero/parent/application/service/AppleEventService.java
+++ b/src/main/java/com/kiero/parent/application/service/AppleEventService.java
@@ -1,0 +1,73 @@
+package com.kiero.parent.application.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.kiero.global.auth.client.apple.dto.AppleServerEvent;
+import com.kiero.global.auth.client.enums.Provider;
+import com.kiero.global.auth.enums.Role;
+import com.kiero.global.auth.jwt.application.port.out.TokenCommandPort;
+import com.kiero.parent.application.port.in.AppleEventUseCase;
+import com.kiero.parent.application.port.in.ParentWithdrawUseCase;
+import com.kiero.parent.application.port.out.AppleEventParsePort;
+import com.kiero.parent.application.port.out.ParentLoadPort;
+import com.kiero.parent.application.port.out.ParentSavePort;
+import com.kiero.parent.domain.Parent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleEventService implements AppleEventUseCase {
+
+	private final AppleEventParsePort appleEventParsePort;
+	private final ParentLoadPort parentLoadPort;
+	private final ParentSavePort parentSavePort;
+	private final TokenCommandPort tokenCommandPort;
+	private final ParentWithdrawUseCase parentWithdrawUseCase;
+
+	@Override
+	@Transactional
+	public void handle(String eventJwt) {
+		AppleServerEvent event = appleEventParsePort.parse(eventJwt);
+		log.info("Apple 서버 이벤트 수신: type={}, sub={}", event.type(), event.sub());
+
+		switch (event.type()) {
+			case EMAIL_ENABLED, EMAIL_DISABLED ->
+				log.info("Apple 이메일 설정 변경 이벤트 수신 (처리 불필요): sub={}", event.sub());
+			case CONSENT_REVOKED -> handleConsentRevoked(event.sub());
+			case ACCOUNT_DELETE -> handleAccountDelete(event.sub());
+			case UNKNOWN -> log.warn("알 수 없는 Apple 서버 이벤트 수신: sub={}", event.sub());
+		}
+	}
+
+	private void handleConsentRevoked(String sub) {
+		Parent parent = parentLoadPort.findParentBySocialIdAndProvider(sub, Provider.APPLE)
+			.orElse(null);
+
+		if (parent == null) {
+			log.warn("Apple consent-revoked 이벤트: 해당 사용자를 찾을 수 없습니다. sub={}", sub);
+			return;
+		}
+
+		parent.updateAppleRefreshToken(null);
+		parentSavePort.save(parent);
+		tokenCommandPort.deleteRefreshToken(parent.getId(), Role.PARENT);
+		log.info("Apple 연동 해제 처리 완료: parentId={}", parent.getId());
+	}
+
+	private void handleAccountDelete(String sub) {
+		Parent parent = parentLoadPort.findParentBySocialIdAndProvider(sub, Provider.APPLE)
+			.orElse(null);
+
+		if (parent == null) {
+			log.warn("Apple account-delete 이벤트: 해당 사용자를 찾을 수 없습니다. sub={}", sub);
+			return;
+		}
+
+		parentWithdrawUseCase.withdraw(parent.getId());
+		log.info("Apple 계정 삭제 처리 완료: parentId={}", parent.getId());
+	}
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #267 

## Work Description ✏️
애플의 새 정책에 따라서 계정 변경 사항을 제공받는 이벤트 수신 API를 구현했습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Apple 서버 이벤트를 수신하고 검증하는 엔드포인트가 추가되었습니다.
  * Apple 계정의 이메일 설정 변경, 동의 철회, 계정 삭제 이벤트를 자동 처리합니다.
  * 동의 철회 시 연결된 토큰을 정리하고, 계정 삭제 시 회원 탈퇴가 진행됩니다.
  * iOS 푸시 알림에 APNS 전용 설정이 포함됩니다.

* **버그 수정**
  * 다양한 FCM 오류 응답에서 무효 토큰을 정확히 식별해 불필요한 재전송을 방지합니다.
  * 유효하지 않은 Apple 이벤트 토큰은 인증 오류로 명확히 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->