### PR TITLE
[refactor] #269 - docker-compose에서 mysql 컨테이너 설정

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,9 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - TZ=Asia/Seoul
       - JAVA_OPTS=-Xms512m -Xmx1024m -XX:+UseG1GC -XX:MaxGCPauseMillis=200
+    depends_on:
+      mysql:
+        condition: service_healthy
     networks:
       - app-network
     restart: always
@@ -33,6 +36,9 @@ services:
       - SPRING_PROFILES_ACTIVE=dev
       - TZ=Asia/Seoul
       - JAVA_OPTS=-Xms512m -Xmx1024m -XX:+UseG1GC -XX:MaxGCPauseMillis=200
+    depends_on:
+      mysql:
+        condition: service_healthy
     networks:
       - app-network
     restart: always
@@ -55,6 +61,35 @@ services:
         reservations:
           cpus: '0.5'
           memory: 512M
+
+  # MySQL
+  mysql:
+    image: mysql:8.0
+    container_name: kiero-mysql
+    ports:
+      - "3306:3306"
+    env_file:
+      - .env.dev
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_USER=${DB_USERNAME}
+      - MYSQL_PASSWORD=${DB_PASSWORD}
+      - TZ=Asia/Seoul
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - app-network
+    restart: always
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${MYSQL_ROOT_PASSWORD}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   # Redis
   redis:
@@ -119,6 +154,9 @@ services:
       - NC_ADMIN_EMAIL=${NOCODB_ADMIN_EMAIL}
       - NC_ADMIN_PASSWORD=${NOCODB_ADMIN_PASSWORD}
       - TZ=Asia/Seoul
+    depends_on:
+      mysql:
+        condition: service_healthy
     volumes:
       - nocodb-data:/usr/app/data
     networks:
@@ -130,6 +168,7 @@ networks:
     driver: bridge
 
 volumes:
+  mysql-data:
   redis-data:
   prometheus-data:
   grafana-data:


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #269

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
비용 절감을 위해 dev 환경에서는 RDS가 아닌 docker compose로 mysql 컨테이너를 구성해 관리하도록 리팩터링 하였습니다.
.dev.env의 database 관련 설정을 업데이트하였습니다. dev database에 저장되어 있는 데이터는 따로 추출해 마이그레이션하거나, prod 출시와 동시에 dev database를 초기화할 생각입니다. 

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 개발 환경에 MySQL 서비스와 데이터 영속성을 위한 저장 공간을 추가했습니다.
  * 애플리케이션과 NocoDB가 MySQL 정상 상태 확인 후 시작되도록 개선했습니다.
  * MySQL 상태 점검을 통해 서비스 초기화 안정성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->