### PR TITLE
[refactor] #276 - 프로메테우스, 그라파나 컨테이너를 dev 환경에서 띄우지 않도록 수정

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -108,38 +108,6 @@ services:
       timeout: 3s
       retries: 3
 
-  # Prometheus
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: kiero-prometheus
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus-data:/prometheus
-    networks:
-      - app-network
-    restart: always
-
-  # Grafana
-  grafana:
-    image: grafana/grafana:latest
-    container_name: kiero-grafana
-    ports:
-      - "3000:3000"
-    env_file:
-      - .env.dev
-    volumes:
-      - grafana-data:/var/lib/grafana
-    environment:
-      - TZ=Asia/Seoul
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
-    depends_on:
-      - prometheus
-    networks:
-      - app-network
-    restart: always
-
   # NocoDB
   nocodb:
     image: nocodb/nocodb:0.265.1
@@ -170,6 +138,4 @@ networks:
 volumes:
   mysql-data:
   redis-data:
-  prometheus-data:
-  grafana-data:
   nocodb-data:

--- a/scripts/deploy-blue-green.sh
+++ b/scripts/deploy-blue-green.sh
@@ -38,7 +38,7 @@ log_info "사용할 Compose 파일: $COMPOSE_FILE"
 if [[ "$COMPOSE_FILE" == *"dev"* ]]; then
     CONTAINER_PREFIX="kiero-dev-app"
     ENV_FILE=".env.dev"
-    SUPPORT_SERVICES="mysql redis prometheus grafana nocodb"
+    SUPPORT_SERVICES="mysql redis nocodb"
 else
     CONTAINER_PREFIX="kiero-prod-app"
     ENV_FILE=".env.prod"


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #276

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- cd가 실패하여 스프링부트 앱 로그를 확인해보니, 특정 시간동안 아무런 작업도 하지 않는 구간이 있었으며, 이는 JVM이 CPU를 받지 못해 멈춰있는 것이라고 추정했습니다. dev에 모니터링을 도입한 것은 시험적인 이유였기 때문에, 트래픽이 많지 않은 환경 특성 상, 그라파나와 프로메테우스 컨테이너를 더 이상 띄우지 않고 리소스를 확보하기로 결정하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 개발 환경에서 Prometheus와 Grafana 모니터링 서비스가 제거되었습니다.
  * 관련 데이터 볼륨이 삭제되어 개발용 인프라 구성이 간소화되었습니다.
  * 개발 모드 배포 시 MySQL, Redis, NocoDB만 지원 서비스로 실행됩니다.
  * 프로덕션 환경의 지원 서비스 구성은 변경되지 않았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->