### PR TITLE
[deploy] #281 - prod cd 트리거 변경, broken pipe 에러 글로벌 예외처리

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -2,8 +2,7 @@ name: CD-Production
 
 on:
   push:
-    tags:
-      - 'v*.*.*'  # 예: v1.0.0 태그가 푸시되면 동작
+    branches: [ main ]
 
 env:
   AWS_REGION: ap-northeast-2

--- a/src/main/java/com/kiero/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kiero/global/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import com.kiero.global.response.base.BaseCode;
@@ -72,6 +73,12 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(AccessDeniedException.class)
 	public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
 		return buildErrorResponse(ErrorCode.ACCESS_DENIED, null);
+	}
+
+	// 클라이언트가 응답을 다 받기 전에 연결을 끊은 경우(Broken pipe).
+	@ExceptionHandler(AsyncRequestNotUsableException.class)
+	public void handleAsyncRequestNotUsable(AsyncRequestNotUsableException e) {
+		log.debug("클라이언트 연결 종료로 응답 쓰기 실패(Broken pipe): {}", e.getMessage());
 	}
 
 	@ExceptionHandler(Exception.class)


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #281

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- main에 push되었을 때 cd가 작동하도록 트리거를 수정하였습니다. 
- 서버 예외가 아닌, 클라이언트가 연결을 중간에 끊어 broken pipe 에러가 발생하였을 시 에러가 그대로 로그에 노출되어 가독성을 해치는 것을 개선하였습니다.

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
