### PR TITLE
[refactor] #284 - 로그인 응답, 내 정보 조회, 내 아이 조회 응답에 pk 추가

### DIFF
--- a/src/main/java/com/kiero/child/application/dto/ChildLoginResponse.java
+++ b/src/main/java/com/kiero/child/application/dto/ChildLoginResponse.java
@@ -3,13 +3,14 @@ package com.kiero.child.application.dto;
 import com.kiero.global.auth.enums.Role;
 
 public record ChildLoginResponse(
+        Long id,
         String lastName,
         String firstName,
         Role role,
         String accessToken,
         String refreshToken
 ) {
-    public static ChildLoginResponse of(String lastName, String firstName, Role role, String accessToken, String refreshToken) {
-        return new ChildLoginResponse(lastName, firstName, role, accessToken, refreshToken);
+    public static ChildLoginResponse of(Long id, String lastName, String firstName, Role role, String accessToken, String refreshToken) {
+        return new ChildLoginResponse(id, lastName, firstName, role, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/kiero/child/application/dto/ChildMeResponse.java
+++ b/src/main/java/com/kiero/child/application/dto/ChildMeResponse.java
@@ -7,6 +7,7 @@ import java.util.Locale;
 import com.kiero.child.domain.Child;
 
 public record ChildMeResponse(
+        Long id,
         String lastName,
         String firstName,
         int coinAmount,
@@ -15,6 +16,7 @@ public record ChildMeResponse(
 ) {
     public static ChildMeResponse from(Child child, LocalDate today) {
         return new ChildMeResponse(
+                child.getId(),
                 child.getLastName(),
                 child.getFirstName(),
                 child.getCoinAmount(),

--- a/src/main/java/com/kiero/global/auth/jwt/application/service/AuthService.java
+++ b/src/main/java/com/kiero/global/auth/jwt/application/service/AuthService.java
@@ -43,7 +43,7 @@ public class AuthService {
 		String refreshToken = issueAndSaveRefreshToken(parent.getId(), authenticationToken);
 		String accessToken = jwtTokenProvider.issueAccessToken(authenticationToken);
 
-		return ParentLoginResponse.of(parent.getName(), parent.getEmail(), parent.getImage(), parent.getRole(),
+		return ParentLoginResponse.of(parent.getId(), parent.getName(), parent.getEmail(), parent.getImage(), parent.getRole(),
 			accessToken, refreshToken);
 	}
 
@@ -64,7 +64,7 @@ public class AuthService {
 		String refreshToken = issueAndSaveRefreshToken(child.getId(), authenticationToken);
 		String accessToken = jwtTokenProvider.issueAccessToken(authenticationToken);
 
-		return ChildLoginResponse.of(child.getLastName(), child.getFirstName(), child.getRole(), accessToken, refreshToken);
+		return ChildLoginResponse.of(child.getId(), child.getLastName(), child.getFirstName(), child.getRole(), accessToken, refreshToken);
 	}
 
 	@Transactional

--- a/src/main/java/com/kiero/parent/application/dto/ChildInfoResponse.java
+++ b/src/main/java/com/kiero/parent/application/dto/ChildInfoResponse.java
@@ -3,11 +3,12 @@ package com.kiero.parent.application.dto;
 import com.kiero.child.domain.Child;
 
 public record ChildInfoResponse(
+        Long id,
         Long childId,
         String childLastName,
         String childFirstName
 ) {
     public static ChildInfoResponse of(Child child) {
-        return new ChildInfoResponse(child.getId(), child.getLastName(), child.getFirstName());
+        return new ChildInfoResponse(child.getId(), child.getId(), child.getLastName(), child.getFirstName());
     }
 }

--- a/src/main/java/com/kiero/parent/application/dto/ParentLoginResponse.java
+++ b/src/main/java/com/kiero/parent/application/dto/ParentLoginResponse.java
@@ -3,6 +3,7 @@ package com.kiero.parent.application.dto;
 import com.kiero.global.auth.enums.Role;
 
 public record ParentLoginResponse(
+	Long id,
 	String name,
 	String email,
 	String image,
@@ -11,7 +12,7 @@ public record ParentLoginResponse(
 	String refreshToken
 ) {
 
-	public static ParentLoginResponse of(String name, String email, String image, Role role, String accessToken, String refreshToken) {
-		return new ParentLoginResponse(name, email, image, role, accessToken, refreshToken);
+	public static ParentLoginResponse of(Long id, String name, String email, String image, Role role, String accessToken, String refreshToken) {
+		return new ParentLoginResponse(id, name, email, image, role, accessToken, refreshToken);
 	}
 }

--- a/src/main/java/com/kiero/parent/application/dto/ParentMeResponse.java
+++ b/src/main/java/com/kiero/parent/application/dto/ParentMeResponse.java
@@ -1,6 +1,7 @@
 package com.kiero.parent.application.dto;
 
 public record ParentMeResponse(
+	Long id,
 	String image,
 	String name,
 	boolean hasPendingChildSession,

--- a/src/main/java/com/kiero/parent/application/service/ParentQueryService.java
+++ b/src/main/java/com/kiero/parent/application/service/ParentQueryService.java
@@ -29,6 +29,7 @@ public class ParentQueryService implements ParentQueryUseCase {
 		boolean hasPendingChildSession = inviteCodeQueryPort.findByParentKey(parentId.toString()).isPresent();
 
 		return new ParentMeResponse(
+			parent.getId(),
 			parent.getImage(),
 			parent.getName(),
 			hasPendingChildSession,

--- a/src/test/java/com/kiero/parent/service/ParentLoginServiceAppleTest.java
+++ b/src/test/java/com/kiero/parent/service/ParentLoginServiceAppleTest.java
@@ -62,7 +62,7 @@ class ParentLoginServiceAppleTest {
 		// given
 		String name = "홍길동";
 		SocialLoginResponse socialResponse = SocialLoginResponse.of(SOCIAL_ID, Provider.APPLE, null, EMAIL, null);
-		ParentLoginResponse loginResponse = ParentLoginResponse.of(name, EMAIL, null, Role.PARENT, "access", "refresh");
+		ParentLoginResponse loginResponse = ParentLoginResponse.of(1L,name, EMAIL, null, Role.PARENT, "access", "refresh");
 
 		when(appleSocialLoginPort.loginWithIdentityToken(IDENTITY_TOKEN)).thenReturn(socialResponse);
 		when(appleAuthPort.exchangeAuthorizationCode(AUTHORIZATION_CODE)).thenReturn(APPLE_REFRESH_TOKEN);
@@ -88,7 +88,7 @@ class ParentLoginServiceAppleTest {
 	void loginWithAppleIdentityToken_nullName_usesEmailAsDisplayName() {
 		// given
 		SocialLoginResponse socialResponse = SocialLoginResponse.of(SOCIAL_ID, Provider.APPLE, null, EMAIL, null);
-		ParentLoginResponse loginResponse = ParentLoginResponse.of(EMAIL, EMAIL, null, Role.PARENT, "access", "refresh");
+		ParentLoginResponse loginResponse = ParentLoginResponse.of(1L,EMAIL, EMAIL, null, Role.PARENT, "access", "refresh");
 
 		when(appleSocialLoginPort.loginWithIdentityToken(IDENTITY_TOKEN)).thenReturn(socialResponse);
 		when(appleAuthPort.exchangeAuthorizationCode(AUTHORIZATION_CODE)).thenReturn(APPLE_REFRESH_TOKEN);
@@ -110,7 +110,7 @@ class ParentLoginServiceAppleTest {
 	void loginWithAppleIdentityToken_blankName_usesEmailAsDisplayName() {
 		// given
 		SocialLoginResponse socialResponse = SocialLoginResponse.of(SOCIAL_ID, Provider.APPLE, null, EMAIL, null);
-		ParentLoginResponse loginResponse = ParentLoginResponse.of(EMAIL, EMAIL, null, Role.PARENT, "access", "refresh");
+		ParentLoginResponse loginResponse = ParentLoginResponse.of(1L,EMAIL, EMAIL, null, Role.PARENT, "access", "refresh");
 
 		when(appleSocialLoginPort.loginWithIdentityToken(IDENTITY_TOKEN)).thenReturn(socialResponse);
 		when(appleAuthPort.exchangeAuthorizationCode(AUTHORIZATION_CODE)).thenReturn(APPLE_REFRESH_TOKEN);
@@ -134,7 +134,7 @@ class ParentLoginServiceAppleTest {
 		String newEmail = "new@apple.com";
 		SocialLoginResponse socialResponse = SocialLoginResponse.of(SOCIAL_ID, Provider.APPLE, null, newEmail, null);
 		Parent existingParent = Parent.create("홍길동", "old@apple.com", null, Role.PARENT, Provider.APPLE, SOCIAL_ID);
-		ParentLoginResponse loginResponse = ParentLoginResponse.of("홍길동", newEmail, null, Role.PARENT, "access", "refresh");
+		ParentLoginResponse loginResponse = ParentLoginResponse.of(1L,"홍길동", newEmail, null, Role.PARENT, "access", "refresh");
 
 		when(appleSocialLoginPort.loginWithIdentityToken(IDENTITY_TOKEN)).thenReturn(socialResponse);
 		when(appleAuthPort.exchangeAuthorizationCode(AUTHORIZATION_CODE)).thenReturn(APPLE_REFRESH_TOKEN);


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #284

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->
- 부모와 아이의 로그인 응답에 pk를 추가하여 반환합니다.
- 부모의 내 아이조회 응답에 pk를 추가하여 반환합니다.
- 부모와 아이의 내 정보 조회 응답에 pk를 추가하여 반환합니다.
- 
## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 로그인 및 내 정보 조회 응답에 부모·자녀 식별자 정보가 포함됩니다.
  * 부모가 조회하는 자녀 정보에도 자녀 식별자가 추가됩니다.
  * 관련 로그인 및 사용자 정보 응답 형식이 일관되게 업데이트되었습니다.

* **테스트**
  * Apple 로그인 시나리오를 새로운 응답 형식에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->