### PR TITLE
[deploy] #289 - tokenservice에 transactional 제거, 부모 탈퇴 시 아이의 연관사진을 s3에서도 삭제하는 로직 구현

### DIFF
--- a/src/main/java/com/kiero/global/auth/jwt/infrastructure/persistence/redis/TokenService.java
+++ b/src/main/java/com/kiero/global/auth/jwt/infrastructure/persistence/redis/TokenService.java
@@ -8,7 +8,6 @@ import com.kiero.global.auth.enums.Role;
 import com.kiero.global.auth.jwt.application.exception.TokenErrorCode;
 import com.kiero.global.exception.KieroException;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -19,7 +18,6 @@ public class TokenService {
 
 	private final TokenRepository tokenRepository;
 
-	@Transactional
 	public void saveRefreshToken(final Long memberId, final String refreshToken, final Role role) {
 		log.info("Saving refresh token for memberId: {}", memberId);
 		tokenRepository.save(Token.of(memberId, refreshToken, role));
@@ -33,7 +31,6 @@ public class TokenService {
 			.orElseThrow(() -> new KieroException(TokenErrorCode.JWT_TOKEN_NOT_FOUND));
 	}
 
-	@Transactional
 	public void deleteRefreshToken(final Long memberId, final Role role) {
 		String key = TokenKeyGenerator.refreshKey(memberId, role);
 		Token token = tokenRepository.findById(key)
@@ -45,7 +42,6 @@ public class TokenService {
 		log.info("Successfully deleted refresh token for memberId: {}", memberId);
 	}
 
-	@Transactional
 	public void deleteRefreshTokensBulk(final List<Long> memberIds, final Role role) {
 		if (memberIds == null || memberIds.isEmpty()) {
 			log.info("No member IDs provided for bulk deletion");

--- a/src/main/java/com/kiero/global/config/S3Config.java
+++ b/src/main/java/com/kiero/global/config/S3Config.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 /**
@@ -33,6 +34,16 @@ public class S3Config {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
                 .build();

--- a/src/main/java/com/kiero/global/s3/service/S3Service.java
+++ b/src/main/java/com/kiero/global/s3/service/S3Service.java
@@ -1,6 +1,8 @@
 package com.kiero.global.s3.service;
 
+import java.net.URI;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -10,7 +12,12 @@ import com.kiero.global.s3.dto.PresignedUrlRequest;
 import com.kiero.global.s3.dto.PresignedUrlResponse;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.Delete;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
@@ -18,11 +25,13 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequ
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3Service {
 
     private final S3Presigner s3Presigner;
+    private final S3Client s3Client;
 
     @Value("${aws.s3.bucket}")
     private String bucketName;
@@ -111,7 +120,40 @@ public class S3Service {
         return presignedRequest.url().toString();
     }
 
-    // UUID를 사용해 고유한 파일명 생성
+    public void deleteObjects(List<String> imageUrls) {
+        if (imageUrls == null || imageUrls.isEmpty()) {
+            return;
+        }
+
+        List<ObjectIdentifier> objects = imageUrls.stream()
+                .map(this::toS3Key)
+                .map(key -> ObjectIdentifier.builder().key(key).build())
+                .toList();
+
+        DeleteObjectsRequest request = DeleteObjectsRequest.builder()
+                .bucket(bucketName)
+                .delete(Delete.builder().objects(objects).quiet(true).build())
+                .build();
+
+        try {
+            s3Client.deleteObjects(request);
+            log.info("S3 파일 삭제 완료: {}건", objects.size());
+        } catch (Exception e) {
+            log.error("S3 파일 삭제 실패: error={}", e.getMessage(), e);
+        }
+    }
+
+    private String toS3Key(String imageUrl) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            return imageUrl;
+        }
+        if (imageUrl.startsWith("http://") || imageUrl.startsWith("https://")) {
+            String path = URI.create(imageUrl).getPath();
+            return path.startsWith("/") ? path.substring(1) : path;
+        }
+        return imageUrl;
+    }
+
     private String generatePath(String prefix, String originalFileName) {
         String uuidFileName = UUID.randomUUID() + "_" + originalFileName;
         return prefix + "/" + uuidFileName;

--- a/src/main/java/com/kiero/parent/application/service/ParentWithdrawService.java
+++ b/src/main/java/com/kiero/parent/application/service/ParentWithdrawService.java
@@ -18,6 +18,7 @@ import com.kiero.feed.application.port.out.FeedItemTransferPort;
 import com.kiero.global.auth.enums.Role;
 import com.kiero.global.auth.jwt.application.port.out.TokenCommandPort;
 import com.kiero.global.exception.KieroException;
+import com.kiero.global.s3.service.S3Service;
 import com.kiero.mission.application.port.out.MissionDeletePort;
 import com.kiero.mission.application.port.out.MissionTransferPort;
 import com.kiero.parent.application.dto.ParentWithdrawnEvent;
@@ -35,7 +36,9 @@ import com.kiero.schedule.application.port.out.ScheduleTransferPort;
 import com.kiero.terms.application.port.out.TermsAgreementDeletePort;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -59,6 +62,7 @@ public class ParentWithdrawService implements ParentWithdrawUseCase {
 	private final FeedItemTransferPort feedItemTransferPort;
 	private final TermsAgreementDeletePort termsAgreementDeletePort;
 	private final ChildDeletePort childDeletePort;
+	private final S3Service s3Service;
 
 	@Override
 	public void withdraw(Long parentId) {
@@ -101,11 +105,13 @@ public class ParentWithdrawService implements ParentWithdrawUseCase {
 		// 부모의 약관 동의 내역 삭제
 		termsAgreementDeletePort.deleteAllByParentId(parentId);
 
-		// 부모 refresh token 삭제
-		tokenCommandPort.deleteRefreshToken(parentId, Role.PARENT);
+		// 부모 refresh token 삭제 (이미 만료·삭제된 경우 무시하고 탈퇴 계속 진행)
+		safeDeleteRefreshToken(parentId, Role.PARENT);
 
 		// 유일한 부모였던 아이: 관련 리소스 삭제 + 알림 + refresh token 삭제 + 아이 삭제
 		for (Long childId : soloChildIds) {
+			List<String> imageKeys = scheduleDeletePort.findImageKeysByChildId(childId);
+			s3Service.deleteObjects(imageKeys);
 			scheduleDeletePort.deleteAllByChildId(childId);
 			missionDeletePort.deleteAllByChildId(childId);
 			couponDeletePort.deleteAllByChildId(childId);
@@ -114,11 +120,20 @@ public class ParentWithdrawService implements ParentWithdrawUseCase {
 
 			parentWithdrawEventPort.publish(new ParentWithdrawnEvent(childId));
 			parentWithdrawNotificationPort.storeWithdrawalMarker(childId);
-			tokenCommandPort.deleteRefreshToken(childId, Role.CHILD);
+			safeDeleteRefreshToken(childId, Role.CHILD);
 			childDeletePort.deleteById(childId);
 		}
 
 		// 부모 하드딜리트 (soloChild 리소스 전부 정리 후 마지막에 삭제)
 		parentDeletePort.deleteParent(parentId);
+	}
+
+	// refresh token이 이미 만료·삭제된 경우에도 탈퇴가 중단되지 않도록 방어
+	private void safeDeleteRefreshToken(Long memberId, Role role) {
+		try {
+			tokenCommandPort.deleteRefreshToken(memberId, role);
+		} catch (KieroException e) {
+			log.warn("탈퇴 중 refresh token 삭제 스킵 (이미 없거나 만료됨): memberId={}, role={}", memberId, role);
+		}
 	}
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDeleteAdapter.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDeleteAdapter.java
@@ -28,4 +28,9 @@ public class ScheduleDeleteAdapter implements ScheduleDeletePort {
 		}
 		scheduleRepository.deleteAllById(schedules.stream().map(Schedule::getId).toList());
 	}
+
+	@Override
+	public List<String> findImageKeysByChildId(Long childId) {
+		return scheduleDetailRepository.findImageUrlsByChildId(childId);
+	}
 }

--- a/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
+++ b/src/main/java/com/kiero/schedule/adapter/out/persistence/ScheduleDetailRepository.java
@@ -218,4 +218,13 @@ public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, 
 		@Param("targetStart") LocalTime targetStart,
 		@Param("targetEnd") LocalTime targetEnd
 	);
+
+	@Query("""
+		SELECT sd.imageUrl
+		FROM ScheduleDetail sd
+		JOIN sd.schedule s
+		WHERE s.child.id = :childId
+		  AND sd.imageUrl IS NOT NULL
+		""")
+	List<String> findImageUrlsByChildId(@Param("childId") Long childId);
 }

--- a/src/main/java/com/kiero/schedule/application/port/out/ScheduleDeletePort.java
+++ b/src/main/java/com/kiero/schedule/application/port/out/ScheduleDeletePort.java
@@ -1,5 +1,8 @@
 package com.kiero.schedule.application.port.out;
 
+import java.util.List;
+
 public interface ScheduleDeletePort {
 	void deleteAllByChildId(Long childId);
+	List<String> findImageKeysByChildId(Long childId);
 }


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->

- closes #289

## Work Description ✏️

<!-- 작업 내용을 간단히 소개주세요 -->

## Trouble Shooting ⚽️

<!-- 어떤 위험이나 장애를 발견했는지 적어주세요 -->

## Related ScreenShot 📷

<!-- 관련 스크린샷을 첨부해주세요 -->

## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢

<!-- 리뷰어들에게 물어볼 점, 할 말 등을 적어주세요 -->
